### PR TITLE
Remove XSummary models #77

### DIFF
--- a/src/pages/groups/Group.vue
+++ b/src/pages/groups/Group.vue
@@ -10,12 +10,23 @@
         @click="$router.back()"
       />
       <!-- eslint-disable vue-i18n/no-raw-text -->
-      <q-toolbar-title>{{group ? group.attributes.name : ""}}</q-toolbar-title>
+      <q-toolbar-title>{{
+        group ? group.attributes.name : ""
+      }}</q-toolbar-title>
 
-      <q-btn v-if="group" right flat round icon="message" @click="contactsView = true" />
+      <q-btn
+        v-if="group"
+        right
+        flat
+        round
+        icon="message"
+        @click="contactsView = true"
+      />
       <share-button
         v-if="group"
-        :text="$t('checkTheExchangeCommunityGroup', {group: group.attributes.name})"
+        :text="
+          $t('checkTheExchangeCommunityGroup', { group: group.attributes.name })
+        "
         :title="group.attributes.name"
       />
     </q-toolbar>
@@ -46,7 +57,10 @@
         <div class="col-12 col-sm-6 col-md-8">
           <div class="text-h6">{{ group.attributes.code }}</div>
           <!-- eslint-disable-next-line vue/no-v-html -->
-          <div v-md2html="group.attributes.description" class="text-onsurface-m"></div>
+          <div
+            v-md2html="group.attributes.description"
+            class="text-onsurface-m"
+          ></div>
           <q-separator spaced />
           <div class="k-inset-actions-md">
             <q-btn
@@ -87,15 +101,14 @@
         </div>
 
         <div class="col-12 col-sm-6 relative-position">
+          <!-- Not providing member types for the moment, as the api does not give it -->
           <group-stats
-            v-if="membersCategory"
             :title="$t('members')"
             icon="account_circle"
             :content="group.relationships.members.meta.count"
             :href="code + '/members'"
-            :items="membersCategory"
+            :items="[]"
           />
-          <q-inner-loading :showing="membersCategory === null" color="icon-dark" />
         </div>
 
         <div class="col-12 col-sm-6 relative-position">
@@ -265,19 +278,9 @@ export default Vue.extend({
         this.isLoading = true;
         this.group = null;
         this.contacts = [];
-        const response = await api.getGroupStatus(code);
+        const response = await api.getGroupWithContacts(code);
         this.group = response.group;
         this.contacts = response.contacts;
-        this.membersCategory = [];
-        const cm = response.group.meta.categoryMembers;
-
-        if (cm) {
-          for (let i = 0; i < cm.length; i++) {
-            const name = this.$t(cm[i][0]);
-            const count = cm[i][1];
-            this.membersCategory.push(count + " " + name);
-          }
-        }
       } finally {
         this.isLoading = false;
       }

--- a/src/pages/groups/GroupList.vue
+++ b/src/pages/groups/GroupList.vue
@@ -1,10 +1,18 @@
 <template>
   <div>
-    <search-bar :title="$t('groupsNearYou')" :back-button="true" @newSearch="fetchGroups" />
+    <search-bar
+      :title="$t('groupsNearYou')"
+      :back-button="true"
+      @newSearch="fetchGroups"
+    />
     <div class="q-pa-md">
       <q-inner-loading :showing="isLoading" color="icon-dark" />
       <div class="row q-col-gutter-md">
-        <div v-for="group of groups" :key="group.id" class="col-12 col-sm-6 col-md-4">
+        <div
+          v-for="group of groups"
+          :key="group.id"
+          class="col-12 col-sm-6 col-md-4"
+        >
           <group-card :group="group" />
         </div>
       </div>
@@ -15,7 +23,7 @@
 <script lang="ts">
 import Vue from "vue";
 import api from "../../services/Api/SocialApi";
-import { GroupSummary } from "./models/model";
+import { Group } from "./models/model";
 
 import SearchBar from "../../components/SearchBar.vue";
 import GroupCard from "../../components/GroupCard.vue";
@@ -33,7 +41,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      groups: [] as GroupSummary[],
+      groups: [] as Group[],
       isLoading: true as boolean,
       location: null as [number, number] | null
     };

--- a/src/pages/groups/GroupOffers.vue
+++ b/src/pages/groups/GroupOffers.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import Vue from "vue";
 import api from "../../services/Api/SocialApi";
-import { OfferSummary } from "./models/model";
+import { Offer } from "./models/model";
 
 import SearchBar from "../../components/SearchBar.vue";
 import OfferCard from "../../components/OfferCard.vue";
@@ -37,7 +37,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      offers: [] as OfferSummary[],
+      offers: [] as Offer[],
       isLoading: true as boolean
     };
   },

--- a/src/pages/groups/models/mockContent/mockData.ts
+++ b/src/pages/groups/models/mockContent/mockData.ts
@@ -1,5 +1,4 @@
 import {
-  GroupSummary,
   Group,
   CollectionResponse,
   ResourceResponseInclude,
@@ -8,13 +7,10 @@ import {
   ResourceIdentifierObject,
   RelatedCollection,
   Category,
-  CategorySummary,
   Member,
-  MemberSummary,
   Address,
   Currency,
   ResourceResponse,
-  OfferSummary,
   Offer
 } from "../model";
 import { LoremIpsum, ILoremIpsumParams } from "lorem-ipsum";
@@ -95,49 +91,15 @@ function relatedCollection(path: string, count: number): RelatedCollection {
 }
 
 /**
- * Mock group summary.
- *
- * @param code Code of group.
- */
-function mockGroupSummary(code: string): GroupSummary {
-  const index = parseInt(code.substr(3));
-
-  return {
-    id: uid(),
-    type: "groups",
-    attributes: {
-      code: code,
-      name: lorem.generateWords(Math.round(Math.random() * 2) + 1),
-      description: testDescriptions[index % testDescriptions.length],
-      image: testImages[index % testImages.length],
-      website: "https://easterislandgroup.org",
-      access: "public",
-      location: testLocations[index % testLocations.length]
-    },
-    links: {
-      self: BASE_URL + "/groups/" + code
-    },
-    meta: {
-      categoryMembers: [
-        ["business", 13],
-        ["organitzacions", 8],
-        ["personals", 40],
-        ["publics", 4]
-      ]
-    }
-  };
-}
-
-/**
  * Mock result for GET /groups/
  *
  * https://app.swaggerhub.com/apis/estevebadia/komunitin-api/0.0.1#/Groups/get_groups
  */
-export function mockGroupList(): CollectionResponse<GroupSummary> {
-  const list = [] as GroupSummary[];
+export function mockGroupList(): CollectionResponse<Group> {
+  const list = [] as Group[];
   for (let index = 1; index < NUM_GROUPS; index++) {
     const code = "GRP" + index;
-    list.push(mockGroupSummary(code));
+    list.push(mockGroup(code).data);
   }
 
   return {
@@ -162,12 +124,19 @@ export function mockGroupList(): CollectionResponse<GroupSummary> {
 export function mockGroup(
   code: string
 ): ResourceResponseInclude<Group, Contact> {
-  const summary = mockGroupSummary(code);
+  const index = parseInt(code.substr(3));
   const contacts = mockContacts(code);
   const group: Group = {
-    ...summary,
+    id: uid(),
+    type: "groups",
     attributes: {
-      ...summary.attributes,
+      code: code,
+      name: lorem.generateWords(Math.round(Math.random() * 2) + 1),
+      description: testDescriptions[index % testDescriptions.length],
+      image: testImages[index % testImages.length],
+      website: "https://easterislandgroup.org",
+      access: "public",
+      location: testLocations[index % testLocations.length],
       created: new Date().toJSON(),
       updated: new Date().toJSON()
     },
@@ -180,6 +149,9 @@ export function mockGroup(
       offers: relatedCollection(`/${code}/offers`, 222),
       needs: relatedCollection(`/${code}/needs`, 12),
       posts: relatedCollection(`/${code}/posts`, 34)
+    },
+    links: {
+      self: BASE_URL + "/" + code
     }
   };
 
@@ -190,9 +162,9 @@ export function mockGroup(
 }
 
 /**
- * Mock category summary.
+ * Mock result for /{groupCode}/categories/id
  */
-function mockCategorySummary(index: number): CategorySummary {
+export function mockCategory(index: number): Category {
   const id = uid();
   return {
     id: id,
@@ -207,21 +179,6 @@ function mockCategorySummary(index: number): CategorySummary {
       created: new Date().toJSON(),
       updated: new Date().toJSON()
     },
-
-    links: {
-      self: BASE_URL + "/categories/" + id
-    }
-  };
-}
-
-/**
- * Mock result for /{groupCode}/categories/id
- */
-export function mockCategory(index: number): Category {
-  const summary = mockCategorySummary(index);
-
-  return {
-    ...summary,
     relationships: {
       group: {
         links: {
@@ -244,6 +201,9 @@ export function mockCategory(index: number): Category {
           count: Math.round(Math.random() * 100)
         }
       }
+    },
+    links: {
+      self: BASE_URL + "/categories/" + id
     }
   };
 }
@@ -274,9 +234,9 @@ export function mockCategoryList(code: string): CollectionResponse<Category> {
 }
 
 /**
- * Mock member summary.
+ * Mock result for /{groupCode}/categories/id
  */
-function mockMemberSummary(index: number): MemberSummary {
+export function mockMember(index: number): Member {
   const id = uid();
   const code = lorem.generateWords(1);
   return {
@@ -294,21 +254,6 @@ function mockMemberSummary(index: number): MemberSummary {
       created: new Date().toJSON(),
       updated: new Date().toJSON()
     },
-
-    links: {
-      self: BASE_URL + "/" + code + "/merbers/" + id
-    }
-  };
-}
-
-/**
- * Mock result for /{groupCode}/categories/id
- */
-export function mockMember(index: number): Member {
-  const summary = mockMemberSummary(index);
-
-  return {
-    ...summary,
     relationships: {
       contacts: {
         data: [
@@ -337,6 +282,9 @@ export function mockMember(index: number): Member {
           count: Math.round(Math.random() * 100)
         }
       }
+    },
+    links: {
+      self: BASE_URL + "/" + code + "/merbers/" + id
     }
   };
 }
@@ -355,8 +303,8 @@ export function mockMemberList(code: string): CollectionResponse<Member> {
   return {
     data: list,
     links: {
-      self: BASE_URL + "/" + code + "/categories",
-      first: BASE_URL + "/" + code + "/categories",
+      self: BASE_URL + "/" + code + "/members",
+      first: BASE_URL + "/" + code + "/members",
       prev: null,
       next: null
     },
@@ -405,19 +353,17 @@ export function mockCurrency(code: string): ResourceResponse<Currency> {
 }
 
 /**
- * Mock offer summary.
- *
- * @param index Index.
+ * Mock result for /{groupCode}/offers/{id}
  */
-function mockOfferSummary(index: number): OfferSummary {
+export function mockOffer(
+  index: number
+): ResourceResponseInclude<Offer, Member> {
+  const member = mockMember(1);
   const code = "GRP" + index;
 
-  return {
+  const offer: Offer = {
     id: uid(),
     type: "offers",
-    links: {
-      self: BASE_URL + code + "/" + "/offers"
-    },
     attributes: {
       name: "Ecologic Bread",
       content:
@@ -440,29 +386,21 @@ function mockOfferSummary(index: number): OfferSummary {
       expires: new Date().toJSON(),
       created: new Date().toJSON(),
       updated: new Date().toJSON()
-    }
-  };
-}
-/**
- * Mock result for /{groupCode}/offers/{id}
- */
-export function mockOffer(): ResourceResponseInclude<Offer, Member> {
-  const summary = mockOfferSummary(1);
-  const member = mockMember(1);
-
-  const offer: Offer = {
-    ...summary,
+    },
     relationships: {
       category: {
         links: {
-          relared: "https://komunitin.org/EITE/categories/food"
+          related: "https://komunitin.org/EITE/categories/food"
         }
       },
       author: {
         links: {
-          related: "https://komunitin.org/EITE/EITE0005"
+          related: "https://komunitin.org/EITE/members/EITE0005"
         }
       }
+    },
+    links: {
+      self: BASE_URL + "/" + code + "/" + "/offers"
     }
   };
 
@@ -475,11 +413,11 @@ export function mockOffer(): ResourceResponseInclude<Offer, Member> {
 /**
  * Mock result for GET /{groupCode}/offers/
  */
-export function mockOfferList(): CollectionResponse<OfferSummary> {
-  const list = [] as OfferSummary[];
+export function mockOfferList(): CollectionResponse<Offer> {
+  const list = [] as Offer[];
 
   for (let index = 1; index < NUM_GROUPS; index++) {
-    list.push(mockOfferSummary(index));
+    list.push(mockOffer(index).data);
   }
 
   return {

--- a/src/pages/groups/models/mockContent/mockData.ts
+++ b/src/pages/groups/models/mockContent/mockData.ts
@@ -91,32 +91,6 @@ function relatedCollection(path: string, count: number): RelatedCollection {
 }
 
 /**
- * Mock result for GET /groups/
- *
- * https://app.swaggerhub.com/apis/estevebadia/komunitin-api/0.0.1#/Groups/get_groups
- */
-export function mockGroupList(): CollectionResponse<Group> {
-  const list = [] as Group[];
-  for (let index = 1; index < NUM_GROUPS; index++) {
-    const code = "GRP" + index;
-    list.push(mockGroup(code).data);
-  }
-
-  return {
-    data: list,
-    links: {
-      self: BASE_URL + "/groups",
-      first: BASE_URL + "/groups",
-      prev: null,
-      next: null
-    },
-    meta: {
-      count: NUM_GROUPS
-    }
-  };
-}
-
-/**
  * Mock result for /{groupCode}
  *
  * https://app.swaggerhub.com/apis/estevebadia/komunitin-api/0.0.1#/Groups/get__groupCode_
@@ -158,6 +132,32 @@ export function mockGroup(
   return {
     data: group,
     included: contacts
+  };
+}
+
+/**
+ * Mock result for GET /groups/
+ *
+ * https://app.swaggerhub.com/apis/estevebadia/komunitin-api/0.0.1#/Groups/get_groups
+ */
+export function mockGroupList(): CollectionResponse<Group> {
+  const list = [] as Group[];
+  for (let index = 1; index < NUM_GROUPS; index++) {
+    const code = "GRP" + index;
+    list.push(mockGroup(code).data);
+  }
+
+  return {
+    data: list,
+    links: {
+      self: BASE_URL + "/groups",
+      first: BASE_URL + "/groups",
+      prev: null,
+      next: null
+    },
+    meta: {
+      count: NUM_GROUPS
+    }
   };
 }
 

--- a/src/pages/groups/models/model.ts
+++ b/src/pages/groups/models/model.ts
@@ -29,14 +29,14 @@ export interface ErrorResponse {
 }
 
 export interface ResourceResponse<T extends ResourceObject> {
-  data: T | null;
+  data: T;
 }
 
 export interface ResourceResponseInclude<
   T extends ResourceObject,
   I extends ResourceObject
 > {
-  data: T | null;
+  data: T;
   included: I[];
 }
 
@@ -79,6 +79,12 @@ export interface RelatedCollection {
   };
 }
 
+export interface RelatedResource {
+  links: {
+    related: string;
+  };
+}
+
 /**
  * Contact model.
  */
@@ -95,28 +101,9 @@ export interface Contact extends ResourceObject {
 export type Access = "public" | "group" | "private";
 
 /**
- * Group summarized model for cards.
- */
-export interface GroupSummary extends ResourceObject {
-  attributes: {
-    code: string;
-    name: string;
-    description: string;
-    image: string;
-    website: string;
-    access: Access;
-    location: Location;
-  };
-  meta: {
-    // Category Members.
-    categoryMembers?: [string, number][];
-  };
-}
-
-/**
  * Full group model.
  */
-export interface Group extends GroupSummary {
+export interface Group extends ResourceObject {
   attributes: {
     code: string;
     name: string;
@@ -141,9 +128,9 @@ export interface Group extends GroupSummary {
 }
 
 /**
- * Categories summary.
+ * Category interface.
  */
-export interface CategorySummary extends ResourceObject {
+export interface Category extends ResourceObject {
   attributes: {
     code: string;
     name: string;
@@ -154,18 +141,8 @@ export interface CategorySummary extends ResourceObject {
     created: string;
     updated: string;
   };
-}
-/**
- * Category interface.
- */
-
-export interface Category extends CategorySummary {
   relationships: {
-    group: {
-      links: {
-        related: string;
-      };
-    };
+    group: RelatedResource;
     needs: RelatedCollection;
     offers: RelatedCollection;
   };
@@ -180,10 +157,11 @@ export interface Address {
   postalCode: string;
   addressRegion: string;
 }
+
 /**
- * Member summary.
+ * Member interface.
  */
-export interface MemberSummary extends ResourceObject {
+export interface Member extends ResourceObject {
   attributes: {
     code: string;
     access: Access;
@@ -196,21 +174,11 @@ export interface MemberSummary extends ResourceObject {
     created: string;
     updated: string;
   };
-}
-/**
- * Member interface.
- */
-
-export interface Member extends MemberSummary {
   relationships: {
     contacts: {
       data: ResourceIdentifierObject[];
     };
-    group: {
-      links: {
-        related: string;
-      };
-    };
+    group: RelatedResource;
     needs: RelatedCollection;
     offers: RelatedCollection;
   };
@@ -255,12 +223,11 @@ export interface Currency extends ResourceObject {
 }
 
 /**
- * Offer summarized model for cards.
+ * Offer model.
  */
-export interface OfferSummary extends ResourceObject {
+export interface Offer extends ResourceObject {
   attributes: {
     name: string;
-    // Some markdown.
     content: string;
     images: ImageObject[];
     access: Access;
@@ -268,22 +235,8 @@ export interface OfferSummary extends ResourceObject {
     created: string;
     updated: string;
   };
-}
-
-/**
- * Full offer model.
- */
-export interface Offer extends OfferSummary {
   relationships: {
-    category: {
-      links: {
-        relared: string;
-      };
-    };
-    author: {
-      links: {
-        related: string;
-      };
-    };
+    category: RelatedResource;
+    author: RelatedResource;
   };
 }

--- a/src/services/Api/SocialApi.ts
+++ b/src/services/Api/SocialApi.ts
@@ -5,7 +5,6 @@ import KOptions from "../../komunitin.json";
 import {
   Group,
   Contact,
-  GroupSummary,
   CollectionResponse,
   ResourceResponseInclude,
   Category,
@@ -36,7 +35,7 @@ export default {
   async getGroups(
     location?: [number, number],
     search?: string
-  ): Promise<GroupSummary[]> {
+  ): Promise<Group[]> {
     let query = "";
     if (location !== undefined) {
       query += "sort=location&geo-position=" + location[0] + "," + location[1];
@@ -48,7 +47,7 @@ export default {
       query = "?" + query;
     }
     try {
-      const response = await client.get<CollectionResponse<GroupSummary>>(
+      const response = await client.get<CollectionResponse<Group>>(
         "/groups" + query
       );
       return response.data.data;
@@ -62,7 +61,7 @@ export default {
    *
    * @param code The group code (usually 4-letters)
    */
-  async getGroupStatus(
+  async getGroupWithContacts(
     code: string
   ): Promise<{ group: Group; contacts: Contact[] }> {
     try {


### PR DESCRIPTION
@edumag He quitado los modelos XSummary por lo que dice en la issue #77 . También he quitado los campos provisionales en el meta para la "members card", ya que no me gustaba como quedaba la API. Creo que de momento es mejor no tener nada.