### PR TITLE
use correct key for ces2demo deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,12 +155,6 @@ jobs:
         && cd ices && git pull && cd ..
         && cd komunitin && git pull
         && ./start.sh --up --public"
-    - name: Install SSH Key for ces2demo
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.CES2DEMO_SSH_PRIVATE_KEY }}
-        known_hosts: 'will-be-set-now'
-        if_key_exists: replace
     - name: Deploy ces2demo.community-exchange.org
       if: github.ref == 'refs/heads/master'
       run: > 


### PR DESCRIPTION
note: CES2DEMO_SSH_PRIVATE_KEY was not needed and has been deleted, we use TEST_DEPLOY_SSH_PRIVATE_KEY instead