### PR TITLE
Update build.yml to fix ces2demo automatic deployment issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install SSH Key
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'pull_request'
       uses: shimataro/ssh-key-action@v2
       with:
         key: ${{ secrets.TEST_DEPLOY_SSH_PRIVATE_KEY }} 


### PR DESCRIPTION
Fix: SSH key installation fails during PR merge
Problem
When merging PRs, the workflow fails with "Secret source: None" because secrets aren't available during PR merge context. This blocks automatic deployments to ces2demo. Solution
Add condition to SSH key step to only run when secrets are available:
- push to master (ces2demo, demo, staging deployments)
- pull_request events (preview deployments)

Impact
✅ Automatic deployments after PR merge 
✅ Fixes ces2demo deployment workflow