### PR TITLE
Feature/add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 * @estevebadia
 
 # =======================
-# BASE TRANSLATION FILES
+# TRANSLATION FILES (BASE & FLAVORS)
 # =======================
 
 # English source files - notify all active translators when these change
@@ -47,14 +47,8 @@ app/src/i18n/nl/*.json @numblock
 notifications/i18n/messages/nl.json @numblock
 app/src-pwa/i18n/nl.json @numblock
 
-
 # Add more languages as translators join:
 # app/src/i18n/de/*.json @german-translator
-# app/src/i18n/it/*.json @italian-translator
-
-# =======================
-# FLAVOR-SPECIFIC TRANSLATIONS
-# =======================
 
 # CES Flavor - English source files
 # Notify translators when CES-specific English strings change
@@ -81,20 +75,5 @@ app/src/i18n/flavors/ces/nl/*.json @numblock
 # app/src/i18n/flavors/[OTHER_FLAVOR]/es/*.json @sseerrggii @estevebadia
 # app/src/i18n/flavors/[OTHER_FLAVOR]/ca/*.json @sseerrggii @estevebadia
 # app/src/i18n/flavors/[OTHER_FLAVOR]/bg/*.json @cesbg1
+# app/src/i18n/flavors/[OTHER_FLAVOR]/nl/*.json @numblock
 
-# =======================
-# FLAVOR CONFIGURATION & ASSETS
-# =======================
-
-# CES Flavor - Assets, styles, config
-# Notify CES maintainer for flavor-specific changes
-# app/.env.flavor.ces @estevebadia
-# assets/flavors/ces/ @estevebadia
-# public/flavors/ces/ @estevebadia
-# app/src/css/flavors/ces/ @estevebadia
-
-# Other flavors:
-# app/.env.flavor.[OTHER_FLAVOR] @flavor-maintainer
-# assets/flavors/[OTHER_FLAVOR]/ @flavor-maintainer
-# public/flavors/[OTHER_FLAVOR]/ @flavor-maintainer
-# app/src/css/flavors/[OTHER_FLAVOR]/ @flavor-maintainer


### PR DESCRIPTION
Add .github/CODEOWNERS with multi-language support

- Notify all translators when English source files change
- French translations: @olivier108
- Spanish & Catalan translations: @sseerrggii @estevebadia 
- Dutch: @numblock
- Bulgarian translations: @cesbg1
- Support for both base and flavor-specific translations
- CES flavor support for all languages

monitored files: 
app/src/i18n/en/*.json 
notifications/i18n/messages/en.json 
app/src-pwa/i18n/en-us.json 