### PR TITLE
Fix issuer key for external state reconciliation

### DIFF
--- a/accounting/src/controller/currency-controller.ts
+++ b/accounting/src/controller/currency-controller.ts
@@ -571,6 +571,7 @@ export class CurrencyControllerImpl implements CurrencyService {
       currentExternalTraderInitialCredit
     }, {
       sponsor: await this.keys.sponsorKey(),
+      issuer: await this.keys.issuerKey(),
       externalTrader: await this.keys.externalTraderKey(),
       externalIssuer: await this.keys.externalIssuerKey(),
       credit: await this.keys.creditKey()

--- a/accounting/src/ledger/ledger.ts
+++ b/accounting/src/ledger/ledger.ts
@@ -321,6 +321,7 @@ export interface LedgerCurrency {
     },
     keys: {
       sponsor: KeyPair,
+      issuer: KeyPair,
       externalTrader: KeyPair,
       externalIssuer: KeyPair,
       credit: KeyPair

--- a/accounting/test/ledger/stellar.test.ts
+++ b/accounting/test/ledger/stellar.test.ts
@@ -189,6 +189,7 @@ describe('Creates stellar elements', async () => {
         currentExternalTraderInitialCredit: "1000.0000000"}
       , {
         sponsor,
+        issuer: currency2Keys.issuer,
         externalTrader: currency2Keys.externalTrader,
         externalIssuer: currency2Keys.externalIssuer,
         credit: currency2Keys.credit


### PR DESCRIPTION
## Summary

Fixes #748 by passing the issuer key into external state reconciliation.

## Root cause

`StellarCurrency.reconcileExternalState()` can call `fundCreditAccountTransaction()` when the credit account drops below its minimum operating balance. That funding operation uses the issuer account as the operation source and adds the issuer public key to the required signer set.

The controller only passed sponsor, external trader, external issuer, and credit keys into `reconcileExternalState()`. When the issuer signature was required, `signerKeys()` mapped the issuer public key to `undefined`, which later reached `Transaction.sign(...)` and crashed with `Cannot read properties of undefined (reading 'signDecorated')`.

## Changes

- Add `issuer` to the `LedgerCurrency.reconcileExternalState()` key contract.
- Pass `issuerKey()` from `CurrencyControllerImpl.reconcileExternalState()`.
- Update the existing ledger test call site to satisfy the corrected key contract.

## Validation

- `corepack pnpm exec prisma generate`
- `corepack pnpm typecheck`
