### PR TITLE
Increase PHP upload limit to 10M for IntegralCES

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -114,6 +114,7 @@ services:
     volumes:
       - "integralces-sites:/var/www/html/sites"
       - "../ices:/var/www/html/sites/all/modules/ices"
+      - "./integralces/php.ini:/usr/local/etc/php/conf.d/uploads.ini"
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/integralces/php.ini
+++ b/integralces/php.ini
@@ -1,0 +1,2 @@
+upload_max_filesize=10M
+post_max_size=10M


### PR DESCRIPTION
## Summary
- Adds `integralces/php.ini` to the komunitin repo with `upload_max_filesize=10M` and `post_max_size=10M`
- Mounts it into the IntegralCES container via a volume in `compose.yml`
- Fixes offer image uploads failing for files above the PHP default 2M limit

## Test plan
- [ ] Restart the IntegralCES container and verify `upload_max_filesize` is now 10M
- [ ] Upload an offer image between 2MB and 10MB and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)