### PR TITLE
Mock file uploads in Mirage tests

### DIFF
--- a/app/src/components/__tests__/ImageUploaderFields.spec.ts
+++ b/app/src/components/__tests__/ImageUploaderFields.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import AvatarField from "../AvatarField.vue"
+import ImageField from "../ImageField.vue"
+import {
+  getMockFileUploadAttempts,
+  resetMockFileUploads,
+  setMockFileUploadLimit
+} from "src/server/FilesServer"
+import { mountComponent, waitFor } from "../../../test/vitest/utils"
+import { createMockImageFile, mockImageUploadProcessing } from "../../../test/vitest/utils/mockImageUpload"
+
+const uploadFile = async (wrapper: Awaited<ReturnType<typeof mountComponent>>, file: File) => {
+  const input = wrapper.get("input[type='file']")
+  Object.defineProperty(input.element, "files", {
+    configurable: true,
+    value: [file]
+  })
+  await input.trigger("change")
+}
+
+describe("image upload fields", () => {
+  beforeEach(() => {
+    resetMockFileUploads()
+    mockImageUploadProcessing()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("uploads a resized image from ImageField before the mock files endpoint would reject the original", async () => {
+    const uploadLimit = 250_000
+    const originalImage = createMockImageFile({
+      encodedSize: 180_000,
+      height: 2400,
+      name: "offer-photo.jpg",
+      size: 1_100_000,
+      type: "image/jpeg",
+      width: 3600
+    })
+
+    setMockFileUploadLimit(uploadLimit)
+    const wrapper = await mountComponent(ImageField, {
+      props: {
+        modelValue: [],
+        label: "Add images",
+        hint: "hint"
+      },
+      login: true
+    })
+
+    await uploadFile(wrapper, originalImage)
+
+    await waitFor(
+      () => wrapper.emitted("update:modelValue")?.at(-1)?.[0]?.[0],
+      "https://files.example/offer-photo.webp",
+      "ImageField should emit the uploaded image url"
+    )
+
+    const [upload] = getMockFileUploadAttempts()
+    expect(originalImage.size).toBeGreaterThan(uploadLimit)
+    expect(upload).toMatchObject({
+      accepted: true,
+      name: "offer-photo.webp",
+      type: "image/webp",
+      url: "https://files.example/offer-photo.webp"
+    })
+    expect(upload.size).toBeLessThanOrEqual(uploadLimit)
+    wrapper.unmount()
+  })
+
+  it("keeps AvatarField unchanged when the mocked endpoint rejects the transformed image as too large", async () => {
+    setMockFileUploadLimit(100_000)
+    const wrapper = await mountComponent(AvatarField, {
+      props: {
+        modelValue: null,
+        text: "Avatar"
+      },
+      login: true
+    })
+
+    await uploadFile(wrapper, createMockImageFile({
+      encodedSize: 180_000,
+      height: 2400,
+      name: "avatar.png",
+      size: 1_100_000,
+      type: "image/png",
+      width: 3600
+    }))
+
+    await waitFor(
+      () => getMockFileUploadAttempts().length,
+      1,
+      "Avatar upload should reach the mock files endpoint"
+    )
+
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined()
+    expect(getMockFileUploadAttempts()[0]).toMatchObject({
+      accepted: false,
+      name: "avatar.webp",
+      type: "image/webp"
+    })
+    wrapper.unmount()
+  })
+})

--- a/app/src/server/FilesServer.ts
+++ b/app/src/server/FilesServer.ts
@@ -1,0 +1,75 @@
+import type { Server } from "miragejs"
+import { Response } from "miragejs"
+import { config } from "src/utils/config"
+
+const fieldName = "files[file]"
+
+export interface MockFileUploadAttempt {
+  accepted: boolean
+  name: string
+  size: number
+  type: string
+  url: string
+}
+
+interface MockFilesState {
+  maxUploadSize: number
+  uploadAttempts: MockFileUploadAttempt[]
+}
+
+const createMockFilesState = (): MockFilesState => ({
+  maxUploadSize: Number.POSITIVE_INFINITY,
+  uploadAttempts: []
+})
+
+let state = createMockFilesState()
+
+const isFormData = (requestBody: unknown): requestBody is FormData => {
+  return requestBody instanceof FormData
+}
+
+const readUploadedFile = (requestBody: unknown) => {
+  const file = isFormData(requestBody) ? requestBody.get(fieldName) : null
+  if (!(file instanceof File)) {
+    throw new Error("Expected uploaded file in mock files endpoint")
+  }
+  return file
+}
+
+export const resetMockFileUploads = () => {
+  state = createMockFilesState()
+}
+
+export const setMockFileUploadLimit = (size: number) => {
+  state.maxUploadSize = size
+}
+
+export const getMockFileUploadAttempts = () => state.uploadAttempts
+
+export default {
+  routes(server: Server) {
+    server.post(config.FILES_URL, (_schema, request) => {
+      const file = readUploadedFile(request.requestBody)
+      const accepted = file.size <= state.maxUploadSize
+      const url = `https://files.example/${file.name}`
+
+      state.uploadAttempts.push({
+        accepted,
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        url
+      })
+
+      if (!accepted) {
+        return new Response(413, {}, { errors: [{ detail: "File too large" }] })
+      }
+
+      return new Response(201, {}, {
+        data: {
+          attributes: { url }
+        }
+      })
+    })
+  }
+}

--- a/app/src/server/index.ts
+++ b/app/src/server/index.ts
@@ -9,6 +9,7 @@ import AuthServer from "./AuthServer";
 import UUIDIndetityManager from "./UUIDManager";
 import AccountingServer from "./AccountingServer";
 import NotificationsServer from "./NotificationsServer";
+import FilesServer from "./FilesServer";
 import type { AnyFactories, AnyModels } from "miragejs/-types";
 
 // Ensure boolean.
@@ -61,6 +62,7 @@ const server = new Server({
     } else {
       this.passthrough(config.NOTIFICATIONS_URL + "/**");
     }
+    FilesServer.routes(this);
 
     // Load the ZXing WASM file from the CDN required for QR scanning.
     this.passthrough("https://fastly.jsdelivr.net/**");

--- a/app/test/vitest/utils/mockImageUpload.ts
+++ b/app/test/vitest/utils/mockImageUpload.ts
@@ -1,0 +1,63 @@
+import { vi } from "vitest"
+import { IMAGE_UPLOAD_WEBP_TYPE } from "src/utils/imageUpload"
+
+interface MockImageFile extends File {
+  __mockEncodedSize?: number
+  __mockHeight?: number
+  __mockWidth?: number
+}
+
+interface MockImageOptions {
+  encodedSize?: number
+  height: number
+  lastModified?: number
+  name: string
+  size: number
+  type: string
+  width: number
+}
+
+export const createMockImageFile = ({
+  encodedSize = 180_000,
+  height,
+  lastModified = 123,
+  name,
+  size,
+  type,
+  width
+}: MockImageOptions) => {
+  const file = new File([new Uint8Array(size)], name, { type, lastModified }) as MockImageFile
+  file.__mockEncodedSize = encodedSize
+  file.__mockHeight = height
+  file.__mockWidth = width
+  return file
+}
+
+export const mockImageUploadProcessing = () => {
+  const originalCreateElement = document.createElement.bind(document)
+  let encodedSize = 0
+
+  vi.stubGlobal("createImageBitmap", vi.fn(async (file: MockImageFile) => {
+    encodedSize = file.__mockEncodedSize ?? 0
+    return {
+      close: vi.fn(),
+      height: file.__mockHeight ?? 1,
+      width: file.__mockWidth ?? 1
+    } as ImageBitmap
+  }))
+
+  vi.spyOn(document, "createElement").mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+    if (tagName.toLowerCase() !== "canvas") {
+      return originalCreateElement(tagName, options)
+    }
+
+    return {
+      height: 0,
+      width: 0,
+      getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+      toBlob: (callback: BlobCallback, type?: string) => {
+        callback(new Blob([new Uint8Array(encodedSize)], { type: type ?? IMAGE_UPLOAD_WEBP_TYPE }))
+      }
+    } as unknown as HTMLCanvasElement
+  })
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic MirageJS mock for the file-upload endpoint so image uploader components can be tested end-to-end against the same `config.FILES_URL` path the app uses. 
- Keep the implementation minimal and focused on the testing need: record upload attempts and allow configurable size-rejection behavior without adding extra production fallbacks.

### Description
- Add `app/src/server/FilesServer.ts` which exposes a Mirage route for `config.FILES_URL` and records each upload attempt, returns a JSON:API-style URL on success, and returns `413` when a configurable max size is exceeded. 
- Register the files mock in the Mirage server by importing and calling `FilesServer.routes(this)` from `app/src/server/index.ts` so tests use the same mock server instance. 
- Add `app/src/components/__tests__/ImageUploaderFields.spec.ts` that verifies `ImageField` uploads transformed WebP files and `AvatarField` handles rejected transformed uploads. 
- Add shared test helpers `app/test/vitest/utils/mockImageUpload.ts` to create deterministic mock image `File`s and stub `createImageBitmap` / canvas `toBlob` behavior for reliable encoding/resizing in tests.

### Testing
- Ran `pnpm exec quasar prepare` to generate the `.quasar` files required by the test environment, which completed successfully. 
- Ran the targeted tests with `pnpm exec vitest run src/components/__tests__/ImageUploaderFields.spec.ts` and the file passed (1 test file, 2 tests passed). 
- Ran `pnpm run lint` which completed successfully. 
- Ran `pnpm exec tsc -p tsconfig.json --noEmit` which failed due to existing project TypeScript issues unrelated to these changes (errors in `quasar.config.ts` and `src/composables/useResources.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42eca04308832e970c10420ea922b4)