### PR TITLE
CSV import: raise filesize limit, add 100-row limit and user-visible error

### DIFF
--- a/app/src/i18n/ca/index.json
+++ b/app/src/i18n/ca/index.json
@@ -408,6 +408,7 @@
   "ErrorNoTrustPath": "El moviment ha fallat perquè no hi ha cap camí d'intercanvi entre les dues monedes",
   "ErrorTransactionError": "El moviment ha fallat",
   "ErrorInvalidTransfersCSVFileLineColumn": "Error llegint el fitxer CSV a la línia {line} columna {column}",
+  "ErrorInvalidTransfersCSVFileLimits": "Selecciona un fitxer CSV o TXT de menys de 100 KB amb un màxim de {rows} files.",
   "ErrorInvalidTransfersCSVFile": "Error llegint el fitxer",
   "ErrorCamNotAllowed": "La app no té permís per accedir a la càmera. Pots activar-ho des de la configuració del navegador.",
   "ErrorCamNotFound": "No s'ha trobat cap càmera en aquest dispositiu.",

--- a/app/src/i18n/en-us/index.json
+++ b/app/src/i18n/en-us/index.json
@@ -425,6 +425,7 @@
   "ErrorNoTrustPath": "Transfer failed because there is no exchange path between the two currencies",
   "ErrorTransactionError": "Transfer failed",
   "ErrorInvalidTransfersCSVFileLineColumn": "Error parsing the CSV file in line {line} column {column}",
+  "ErrorInvalidTransfersCSVFileLimits": "Select a CSV or TXT file under 100 KB with at most {rows} rows.",
   "ErrorInvalidTransfersCSVFile": "Error reading the file",
   "ErrorCamNotAllowed": "The app does not have permission to use the camera. You can allow it in the browser settings.",
   "ErrorCamNotFound": "No camera found in this device",

--- a/app/src/i18n/es/index.json
+++ b/app/src/i18n/es/index.json
@@ -409,6 +409,7 @@
   "ErrorNoTrustPath": "El movimiento ha fallado porque no existe ningún camino de intercambio entre las dos monedas",
   "ErrorTransactionError": "El movimiento ha fallado",
   "ErrorInvalidTransfersCSVFileLineColumn": "Error leyendo el fichero CSV en la línea {line} columna {column}",
+  "ErrorInvalidTransfersCSVFileLimits": "Selecciona un fichero CSV o TXT de menos de 100 KB con un máximo de {rows} filas.",
   "ErrorInvalidTransfersCSVFile": "Error leyendo el fitxer",
   "ErrorCamNotAllowed": "La app no tiene permiso para utilizar la camara. Activa los permisos en la configuración del navegador.",
   "ErrorCamNotFound": "No se ha encontrado ninguna camara en este dispositivo.",

--- a/app/src/i18n/fr/index.json
+++ b/app/src/i18n/fr/index.json
@@ -419,6 +419,7 @@
   "ErrorNoTrustPath": "L'échange a échoué car il n'y a pas de chemin d'échange entre les deux monnaies",
   "ErrorTransactionError": "L'échange a échoué",
   "ErrorInvalidTransfersCSVFileLineColumn": "Erreur d'analyse du fichier CSV à la ligne {line} colonne {column}",
+  "ErrorInvalidTransfersCSVFileLimits": "Sélectionnez un fichier CSV ou TXT de moins de 100 Ko avec au maximum {rows} lignes.",
   "ErrorInvalidTransfersCSVFile": "Erreur de lecture du fichier",
   "ErrorCamNotAllowed": "L'application n'a pas la permission d'utiliser la caméra. Vous pouvez l'autoriser dans les paramètres du navigateur.",
   "ErrorCamNotFound": "Aucune caméra trouvée sur cet appareil",

--- a/app/src/i18n/it/index.json
+++ b/app/src/i18n/it/index.json
@@ -430,6 +430,7 @@
   "ErrorNoTrustPath": "Il movimento non è riuscito perché non esiste un percorso di scambio tra le due valute",
   "ErrorTransactionError": "Il movimento non è andato a buon fine",
   "ErrorInvalidTransfersCSVFileLineColumn": "Errore durante l'analisi del file CSV nella riga {line} colonna {column}",
+  "ErrorInvalidTransfersCSVFileLimits": "Seleziona un file CSV o TXT inferiore a 100 KB con al massimo {rows} righe.",
   "ErrorInvalidTransfersCSVFile": "Errore durante la lettura del file",
   "ErrorCamNotAllowed": "L'app non ha il permesso di usare la fotocamera. Puoi consentirlo nelle impostazioni del browser.",
   "ErrorCamNotFound": "Nessuna fotocamera trovata in questo dispositivo",

--- a/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
+++ b/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
@@ -13,8 +13,9 @@
         :label="$t('selectFile')"
         :hint="$t('selectFileHint')"
         accept=".csv, .txt"
-        max-file-size="10000"
+        max-file-size="100000"
         :error-message="fileErrorMessage"
+        @rejected="onRejectedFiles"
         :error="!!fileErrorMessage"
       >
         <template #append>
@@ -52,6 +53,11 @@ const myCurrency = computed(() => store.getters.myAccount.currency)
 // File import
 const file = ref<File|null>()
 const fileErrorMessage = ref<string>("")
+const maxImportRows = 100
+
+const onRejectedFiles = () => {
+  fileErrorMessage.value = t("ErrorInvalidTransfersCSVFileLimits", {rows: maxImportRows})
+}
 
 const fetchAccountByCode = async (code: string) => {
   code = normalizeAccountCode(code, myCurrency.value)
@@ -82,6 +88,9 @@ const parseTransfersFile = async (content: string[][]) : Promise<TransferRow[]> 
   if (parseAmount(lastHeader, myCurrency.value) === false) {
     content.shift()
     line++
+  }
+  if (content.length > maxImportRows) {
+    throw new KError(KErrorCode.InvalidTransfersCSVFile, "Too many rows", undefined, {maxRows: maxImportRows})
   }
   const parsed = []
   // Parse the rest of the rows
@@ -135,6 +144,9 @@ const parseTransfersFile = async (content: string[][]) : Promise<TransferRow[]> 
   }
   return parsed
   } catch (error) {
+    if (error instanceof KError && (error.debugInfo as {maxRows?: number} | undefined)?.maxRows) {
+      throw error
+    }
     throw new KError(KErrorCode.InvalidTransfersCSVFile, "Error parsing transfers file", error, {line, column})
   }
 }
@@ -150,8 +162,12 @@ const importFile = async () => {
     emit("import", rows)
   } catch (error) {
     if (error instanceof KError && error.code === KErrorCode.InvalidTransfersCSVFile && error.debugInfo) {
-      const debugInfo = error.debugInfo as {line: number, column: number}
-      fileErrorMessage.value = t("ErrorInvalidTransfersCSVFileLineColumn", {line: debugInfo.line, column: debugInfo.column})  
+      const debugInfo = error.debugInfo as {line?: number, column?: number, maxRows?: number}
+      if (debugInfo.maxRows) {
+        fileErrorMessage.value = t("ErrorInvalidTransfersCSVFileLimits", {rows: debugInfo.maxRows})
+      } else {
+        fileErrorMessage.value = t("ErrorInvalidTransfersCSVFileLineColumn", {line: debugInfo.line, column: debugInfo.column})
+      }
     } else {
       fileErrorMessage.value = t("ErrorInvalidTransfersCSVFile")
     }

--- a/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
+++ b/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
@@ -148,7 +148,7 @@ const parseTransfersFile = async (content: string[][]) : Promise<TransferRow[]> 
   }
   return parsed
   } catch (error) {
-    if (error instanceof KError && (error.debugInfo as {maxRows?: number} | undefined)?.maxRows) {
+    if (error instanceof KError) {
       throw error
     }
     throw new KError(KErrorCode.InvalidTransfersCSVFile, "Error parsing transfers file", error, {line, column})

--- a/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
+++ b/app/src/pages/transactions/CreateTransactionLoadFileBtn.vue
@@ -9,6 +9,7 @@
     <template #default>
       <q-file 
         v-model="file"
+        @update:model-value="fileErrorMessage = ''"
         outlined
         :label="$t('selectFile')"
         :hint="$t('selectFileHint')"
@@ -35,6 +36,7 @@ import { normalizeAccountCode, parseAmount } from 'src/plugins/FormatCurrency';
 import type { TransferRow } from "./CreateTransactionMultiple.vue";
 import { useStore } from "vuex";
 import type { ExtendedAccount } from "src/store/model";
+import type { QRejectedEntry } from "quasar";
 
 const props = defineProps<{
   code: string,
@@ -55,8 +57,10 @@ const file = ref<File|null>()
 const fileErrorMessage = ref<string>("")
 const maxImportRows = 100
 
-const onRejectedFiles = () => {
-  fileErrorMessage.value = t("ErrorInvalidTransfersCSVFileLimits", {rows: maxImportRows})
+const onRejectedFiles = (rejectedEntries: QRejectedEntry[]) => {
+  fileErrorMessage.value = rejectedEntries.some(entry => entry.failedPropValidation === "max-file-size")
+    ? t("ErrorInvalidTransfersCSVFileLimits", {rows: maxImportRows})
+    : t("ErrorInvalidTransfersCSVFile")
 }
 
 const fetchAccountByCode = async (code: string) => {


### PR DESCRIPTION
### Motivation
- Users experienced silent CSV import failures when `q-file` rejected files (file-size rejection was not surfaced and the 10 KB limit was too low). 
- Prefer a parsed-row limit as the primary guard (so a too-large but valid-format file shows a row-limit message instead of a generic file-size error).

### Description
- Increased `q-file` `max-file-size` from `10000` to `100000` in `app/src/pages/transactions/CreateTransactionLoadFileBtn.vue` and wired the `@rejected` event to show a visible error. 
- Added a `maxImportRows = 100` parsed-row check in `parseTransfersFile` that throws `KError` with `debugInfo.maxRows` when exceeded. 
- Updated import error handling to display a new non-flavorized i18n message key `ErrorInvalidTransfersCSVFileLimits` when the row or file limits are hit. 
- Added `ErrorInvalidTransfersCSVFileLimits` translations to supported languages (`en-us`, `ca`, `es`, `fr`, `it`).

### Testing
- Ran `pnpm exec eslint --max-warnings 0 src/pages/transactions/CreateTransactionLoadFileBtn.vue` which passed. 
- Validated updated JSON translation files with `python3 -m json.tool` for `app/src/i18n/*/index.json`, which succeeded. 
- Ran the repository `pnpm lint` which failed due to existing unrelated `@typescript-eslint/no-unnecessary-type-assertion` errors in other files (these errors pre-existed and are not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ddcf78fc832eb5589d6f9903edf8)