### PR TITLE
Persist local Stellar quickstart data

### DIFF
--- a/accounting/compose.yaml
+++ b/accounting/compose.yaml
@@ -22,10 +22,15 @@ services:
       # AWS_REGION: gra
       # AWS_S3_FORCE_PATH_STYLE: false
   stellar:
-    image: stellar/quickstart
+    image: stellar/quickstart:latest
     container_name: stellar
     restart: unless-stopped
     ports:
       - "8000:8000"
+    volumes:
+      - stellar-data:/opt/stellar
     environment:
       NETWORK: local
+
+volumes:
+  stellar-data:


### PR DESCRIPTION
## Summary

- explicitly use the `stellar/quickstart:latest` image for local accounting development
- persist `/opt/stellar` in a named Docker volume

## Why

The cached Quickstart image took about 108 seconds before Friendbot became available, and recreating an ephemeral container repeated Stellar initialization. Refreshing the image reduced Friendbot readiness to about 18.5 seconds; reusing the persisted state after a container replacement reduced it further to about 11.4 seconds.

This keeps the local Compose setup simple while making repeated accounting test runs faster.

## Validation

- `docker compose -f accounting/compose.yaml config -q`
- Friendbot funding returned HTTP 200 after the initial persistent boot
- Friendbot funding returned HTTP 200 after force-recreating the container with the named volume
- confirmed PostgreSQL, Core, Horizon, RPC, and Friendbot initialization were reused