### PR TITLE
Fix DEF-002 by Persisting Canonical Accounting Links

### DIFF
--- a/social/prisma/migrations/20260504160633_init/migration.sql
+++ b/social/prisma/migrations/20260504160633_init/migration.sql
@@ -26,11 +26,14 @@ CREATE TABLE "Group" (
     "settings" JSONB,
     "meta" JSONB,
     "currencyId" TEXT,
+    "currencyHref" VARCHAR(2048),
     "created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated" TIMESTAMP(3) NOT NULL,
     "deleted" TIMESTAMP(3),
 
-    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Group_currency_reference_check"
+        CHECK (("currencyId" IS NULL) = ("currencyHref" IS NULL))
 );
 
 -- CreateTable
@@ -60,12 +63,15 @@ CREATE TABLE "Member" (
     "contacts" JSONB,
     "meta" JSONB,
     "accountId" UUID,
+    "accountHref" VARCHAR(2048),
     "created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated" TIMESTAMP(3) NOT NULL,
     "deleted" TIMESTAMP(3),
     "groupId" UUID NOT NULL,
 
-    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Member_account_reference_check"
+        CHECK (("accountId" IS NULL) = ("accountHref" IS NULL))
 );
 
 -- CreateTable

--- a/social/prisma/schema.prisma
+++ b/social/prisma/schema.prisma
@@ -71,8 +71,9 @@ model Group {
   settings Json? // GroupSettings
   meta     Json? // GroupMeta
 
-  // Currency id in accounting service.
-  currencyId String?
+  // Currency reference in accounting service.
+  currencyId   String?
+  currencyHref String? @db.VarChar(2048)
 
   created DateTime  @default(now())
   updated DateTime  @updatedAt
@@ -126,8 +127,9 @@ model Member {
 
   meta Json? // MemberMeta
 
-  // Account id in accounting service.
-  accountId String? @db.Uuid
+  // Account reference in accounting service.
+  accountId   String? @db.Uuid
+  accountHref String? @db.VarChar(2048)
 
   created DateTime  @default(now())
   updated DateTime  @updatedAt

--- a/social/src/clients/accounting.ts
+++ b/social/src/clients/accounting.ts
@@ -16,6 +16,9 @@ type JsonApiResource = {
   id: string
   type: string
   attributes?: Record<string, unknown>
+  links: {
+    self: string
+  }
 }
 
 type JsonApiDoc = {
@@ -30,6 +33,7 @@ type RequestOptions = {
 export type CurrencyStatus = "new" | "active" | "disabled" | "deleted"
 export type Currency = {
   id: string
+  href: string
   type: "currencies"
   code: string
   status: CurrencyStatus
@@ -39,6 +43,7 @@ export type Currency = {
 export type AccountStatus = "active" | "disabled" | "suspended" | "deleted"
 export type Account = {
   id: string
+  href: string
   type: "accounts"
   code: string
   status: AccountStatus
@@ -74,8 +79,8 @@ const toResource = (data: JsonApiResource | JsonApiResource[] | undefined) => {
     throw internalError('Expected single resource but got an array')
   }
   if (typeof data === 'object' && data !== null && 'id' in data && 'type' in data) {
-    const { id, type, attributes } = data as JsonApiResource
-    return { id, type, ...attributes }
+    const { id, type, attributes, links } = data as JsonApiResource
+    return { id, type, ...attributes, href: links.self }
   }
   return undefined
 }
@@ -266,12 +271,4 @@ class AccountingClient {
 
 export const createAccountingClient = (ctx: AuthContext) => {
   return new AccountingClient(ctx)
-}
-
-export const getAccountingCurrencyUrl = (code: string) => {
-  return accountingUrl(`/${code}/currency`)
-}
-
-export const getAccountingAccountUrl = (currencyCode: string, accountId: string) => {
-  return accountingUrl(`/${currencyCode}/accounts/${accountId}`)
 }

--- a/social/src/features/groups/serialize.ts
+++ b/social/src/features/groups/serialize.ts
@@ -1,6 +1,5 @@
 import TsJapi from 'ts-japi'
 import { config } from '../../config'
-import { getAccountingCurrencyUrl } from '../../clients/accounting'
 import { externalResourceSerializer, getResourceLink, SerializerOptions, ToManyRelator } from '../../server/jsonapi-serialize'
 import type { GroupSettings } from './schema'
 import type { Group, SerializableGroup } from './types'
@@ -60,13 +59,13 @@ export const GroupSerializer = new Serializer<SerializableGroup>('groups', {
       }
     }, GroupSettingsSerializer, { relatedName: 'settings' }),
     currency: new Relator<SerializableGroup, { id: string; href: string }>(async (group) => {
-      if (!group.currencyId) {
+      if (!group.currencyId ||!group.currencyHref) {
         return undefined
       }
 
       return {
         id: group.currencyId,
-        href: getAccountingCurrencyUrl(group.code),
+        href: group.currencyHref,
       }
     }, ExternalCurrencySerializer, { relatedName: 'currency' }),
     admins: new ToManyRelator<SerializableGroup>(

--- a/social/src/features/groups/serialize.ts
+++ b/social/src/features/groups/serialize.ts
@@ -59,7 +59,7 @@ export const GroupSerializer = new Serializer<SerializableGroup>('groups', {
       }
     }, GroupSettingsSerializer, { relatedName: 'settings' }),
     currency: new Relator<SerializableGroup, { id: string; href: string }>(async (group) => {
-      if (!group.currencyId ||!group.currencyHref) {
+      if (!group.currencyId || !group.currencyHref) {
         return undefined
       }
 

--- a/social/src/features/groups/service.ts
+++ b/social/src/features/groups/service.ts
@@ -358,9 +358,8 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
     if (status === 'active' || status === 'disabled') {
       const currencyAttributes = (meta ?? group.meta)?.request?.currency
       const currency = await syncCurrencyStatus(ctx, group, status, currencyAttributes)
-      if (!group.currencyId) {
-        data.currencyId = currency.id
-      }
+      data.currencyId = currency.id
+      data.currencyHref = currency.href
     }
 
     if (group.status === 'pending' && status === 'active') {

--- a/social/src/features/members/serialize.ts
+++ b/social/src/features/members/serialize.ts
@@ -1,6 +1,5 @@
 import TsJapi from 'ts-japi'
 import { externalResourceSerializer, getResourceLink, relatedResource, SerializerOptions } from '../../server/jsonapi-serialize'
-import { getAccountingAccountUrl } from '../../clients/accounting'
 import { GroupSerializer } from '../groups/serialize'
 import type { SerializableGroup } from '../groups/types'
 import { postRelationships } from '../posts/relationship-serialize'
@@ -38,13 +37,13 @@ export const MemberSerializer = new Serializer<SerializableMember>('members', {
       { relatedName: 'group' },
     ),
     account: new Relator<SerializableMember, { id: string; href: string }>(async (member) => {
-      if (!member.accountId) {
+      if (!member.accountId || !member.accountHref) {
         return undefined
       }
 
       return {
         id: member.accountId,
-        href: getAccountingAccountUrl(member.tenantId, member.accountId),
+        href: member.accountHref,
       }
     }, ExternalAccountSerializer, { relatedName: 'account' }),
   }

--- a/social/src/features/members/service.ts
+++ b/social/src/features/members/service.ts
@@ -372,9 +372,8 @@ export const patchMember = async (
     if (to === 'active' || to === 'disabled' || to === 'suspended') {
       const currencyCode = getCurrencyCode(group)
       const account = await syncAccountStatus(ctx, member, currencyCode, to)
-      if (!member.accountId) {
-        data.accountId = account.id
-      }     
+      data.accountId = account.id
+      data.accountHref = account.href
     }
     data.status = to
   }

--- a/social/test/group.test.ts
+++ b/social/test/group.test.ts
@@ -5,6 +5,7 @@ import { tenantDb } from '../src/server/multitenant'
 import prisma from '../src/utils/prisma'
 import { Scope } from '../src/server/context'
 import { auth, serviceAuth } from './mocks/auth'
+import { accountingCurrencyHref } from './mocks/accounting'
 import {
   getAccountingRequests,
   getAccountingRequestPaths,
@@ -414,7 +415,7 @@ describe('Groups endpoints', () => {
     assert.strictEqual(res.body.data[0].relationships.currency.data.type, 'currencies')
     assert.strictEqual(res.body.data[0].relationships.currency.data.id, currencyId)
     assert.strictEqual(res.body.data[0].relationships.currency.data.meta.external, true)
-    assert.strictEqual(res.body.data[0].relationships.currency.data.meta.href, 'http://localhost:2025/currency-include-group/currency')
+    assert.strictEqual(res.body.data[0].relationships.currency.data.meta.href, accountingCurrencyHref('currency-include-group'))
 
     assert.ok(Array.isArray(res.body.included))
     assert.strictEqual(res.body.included.length, 1)
@@ -423,7 +424,7 @@ describe('Groups endpoints', () => {
       id: currencyId,
       meta: {
         external: true,
-        href: 'http://localhost:2025/currency-include-group/currency',
+        href: accountingCurrencyHref('currency-include-group'),
       },
     })
     assert.deepStrictEqual(getAccountingRequestPaths(), [])
@@ -671,7 +672,7 @@ describe('Groups endpoints', () => {
     assert.strictEqual(res.body.data.relationships.currency.data.type, 'currencies')
     assert.strictEqual(res.body.data.relationships.currency.data.id, currencyId)
     assert.strictEqual(res.body.data.relationships.currency.data.meta.external, true)
-    assert.strictEqual(res.body.data.relationships.currency.data.meta.href, 'http://localhost:2025/single-currency-include-group/currency')
+    assert.strictEqual(res.body.data.relationships.currency.data.meta.href, accountingCurrencyHref('single-currency-include-group'))
 
     assert.ok(Array.isArray(res.body.included))
     assert.deepStrictEqual(res.body.included[0], {
@@ -679,7 +680,7 @@ describe('Groups endpoints', () => {
       id: currencyId,
       meta: {
         external: true,
-        href: 'http://localhost:2025/single-currency-include-group/currency',
+        href: accountingCurrencyHref('single-currency-include-group'),
       },
     })
     assert.deepStrictEqual(getAccountingRequestPaths(), [])
@@ -993,7 +994,8 @@ describe('Groups endpoints', () => {
     assert.strictEqual(res.body.data.attributes.meta, null)
     assert.strictEqual(res.body.data.relationships.currency.data.type, 'currencies')
     assert.strictEqual(res.body.data.relationships.currency.data.meta.external, true)
-    assert.strictEqual(res.body.data.relationships.currency.data.meta.href, 'http://localhost:2025/activate-group/currency')
+    const currencyHref = accountingCurrencyHref('activate-group')
+    assert.strictEqual(res.body.data.relationships.currency.data.meta.href, currencyHref)
 
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
@@ -1004,6 +1006,7 @@ describe('Groups endpoints', () => {
     const group = await db.group.findFirstOrThrow()
     assert.strictEqual(group.status, 'active')
     assert.strictEqual(group.currencyId, res.body.data.relationships.currency.data.id)
+    assert.strictEqual(group.currencyHref, currencyHref)
     assert.strictEqual(group.meta, null)
 
     const events = getNotificationsEvents() as any[]
@@ -1061,6 +1064,9 @@ describe('Groups endpoints', () => {
 
     const db = tenantDb(prisma, 'adopt-group')
     const group = await db.group.findFirstOrThrow()
+    assert.strictEqual(group.currencyId, currency.id)
+    assert.strictEqual(group.currencyHref, currency.href)
+    assert.strictEqual(res.body.data.relationships.currency.data.meta.href, currency.href)
     assert.strictEqual(group.meta, null)
     assert.strictEqual(res.body.data.attributes.meta, null)
   })

--- a/social/test/member.test.ts
+++ b/social/test/member.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert'
 import request from 'supertest'
 import { tenantDb } from '../src/server/multitenant'
 import prisma from '../src/utils/prisma'
-import { Scope } from '../src/server/context'
 import { auth, serviceAuth } from './mocks/auth'
+import { accountingAccountHref } from './mocks/accounting'
 import {
   getAccountingRequestPaths,
   getNotificationsEvents,
@@ -227,7 +227,7 @@ describe('Members endpoints', () => {
     assert.strictEqual(res.body.data[0].relationships.account.data.type, 'accounts')
     assert.strictEqual(res.body.data[0].relationships.account.data.id, accountId)
     assert.strictEqual(res.body.data[0].relationships.account.data.meta.external, true)
-    assert.strictEqual(res.body.data[0].relationships.account.data.meta.href, `http://localhost:2025/members-include-account/accounts/${accountId}`)
+    assert.strictEqual(res.body.data[0].relationships.account.data.meta.href, accountingAccountHref('members-include-account', accountId))
 
     assert.ok(Array.isArray(res.body.included))
     assert.strictEqual(res.body.included.length, 1)
@@ -236,7 +236,7 @@ describe('Members endpoints', () => {
       id: accountId,
       meta: {
         external: true,
-        href: `http://localhost:2025/members-include-account/accounts/${accountId}`,
+        href: accountingAccountHref('members-include-account', accountId),
       },
     })
     assert.deepStrictEqual(getAccountingRequestPaths(), [])
@@ -541,7 +541,9 @@ describe('Members endpoints', () => {
     assert.ok(approved.body.data.attributes.accountId)
     assert.strictEqual(approved.body.data.relationships.account.data.type, 'accounts')
     assert.strictEqual(approved.body.data.relationships.account.data.meta.external, true)
-    assert.strictEqual(approved.body.data.relationships.account.data.meta.href, `http://localhost:2025/${currency.code}/accounts/${approved.body.data.attributes.accountId}`)
+    const accountHref = accountingAccountHref(currency.code, approved.body.data.attributes.accountId)
+    assert.strictEqual(approved.body.data.relationships.account.data.meta.href, accountHref)
+    
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
       [`GET /${currency.code}/accounts`, `POST /${currency.code}/accounts`],
@@ -587,10 +589,15 @@ describe('Members endpoints', () => {
 
     assert.strictEqual(approved.body.data.attributes.accountId, account.id)
     assert.strictEqual(approved.body.data.relationships.account.data.id, account.id)
+    assert.strictEqual(approved.body.data.relationships.account.data.meta.href, account.href)
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
       [`GET /${currency.code}/accounts`],
     )
+    const db = tenantDb(prisma, currency.code)
+    const storedMember = await db.member.findFirstOrThrow({ where: { id: member.id } })
+    assert.strictEqual(storedMember.accountId, account.id)
+    assert.strictEqual(storedMember.accountHref, account.href)
   })
 
   test('PATCH /:code/members/:member allows member admin to disable and reactivate with accounting sync', async () => {

--- a/social/test/member.test.ts
+++ b/social/test/member.test.ts
@@ -594,10 +594,6 @@ describe('Members endpoints', () => {
       getAccountingRequestPaths(),
       [`GET /${currency.code}/accounts`],
     )
-    const db = tenantDb(prisma, currency.code)
-    const storedMember = await db.member.findFirstOrThrow({ where: { id: member.id } })
-    assert.strictEqual(storedMember.accountId, account.id)
-    assert.strictEqual(storedMember.accountHref, account.href)
   })
 
   test('PATCH /:code/members/:member allows member admin to disable and reactivate with accounting sync', async () => {

--- a/social/test/mocks/accounting.ts
+++ b/social/test/mocks/accounting.ts
@@ -1,0 +1,9 @@
+export const accountingPublicBaseUrl = 'https://accounting.test'
+
+export const accountingCurrencyHref = (currencyCode: string) => {
+  return `${accountingPublicBaseUrl}/${currencyCode}/currency`
+}
+
+export const accountingAccountHref = (currencyCode: string, accountId: string) => {
+  return `${accountingPublicBaseUrl}/${currencyCode}/accounts/${accountId}`
+}

--- a/social/test/mocks/handlers.ts
+++ b/social/test/mocks/handlers.ts
@@ -1,17 +1,20 @@
 import { http, HttpResponse } from 'msw'
 import { CLIENT_ID } from '../../src/config'
 import { Scope } from '../../src/server/scopes'
+import { accountingAccountHref, accountingCurrencyHref } from './accounting'
 import { getJwks } from './auth'
 import { toUuid } from './utils'
 
 type MockCurrency = {
   id: string
+  href: string
   code: string
   status: 'active' | 'disabled' | 'deleted'
 }
 
 type MockAccount = {
   id: string
+  href: string
   code: string
   currencyCode: string
   userIds: string[]
@@ -65,7 +68,7 @@ export const seedAccountingCurrency = (
   id = toUuid(`accounting-currency-${code}`),
   status: MockCurrency['status'] = 'active',
 ): MockCurrency => {
-  const currency = { id, code, status }
+  const currency = { id, href: accountingCurrencyHref(code), code, status }
   accountingCurrencies.set(code, currency)
   return currency
 }
@@ -78,7 +81,15 @@ export const seedAccountingAccount = (
   status: MockAccount['status'] = 'active',
   balance = 0,
 ): MockAccount => {
-  const account = { id, code, currencyCode, userIds, status, balance }
+  const account = {
+    id,
+    href: accountingAccountHref(currencyCode, id),
+    code,
+    currencyCode,
+    userIds,
+    status,
+    balance,
+  }
   const accounts = accountingAccounts.get(currencyCode) ?? new Map<string, MockAccount>()
   accounts.set(code, account)
   accountingAccounts.set(currencyCode, accounts)
@@ -162,6 +173,9 @@ const requireAccountingAuthorization = (request: Request): Response | null => {
 const serializeCurrency = (currency: MockCurrency) => ({
   type: 'currencies',
   id: currency.id,
+  links: {
+    self: currency.href,
+  },
   attributes: {
     code: currency.code,
     status: currency.status,
@@ -171,6 +185,9 @@ const serializeCurrency = (currency: MockCurrency) => ({
 const serializeAccount = (account: MockAccount) => ({
   type: 'accounts',
   id: account.id,
+  links: {
+    self: account.href,
+  },
   attributes: {
     code: account.code,
     status: account.status,

--- a/social/test/mocks/seed.ts
+++ b/social/test/mocks/seed.ts
@@ -148,7 +148,7 @@ export const seedGroup = async (data: SeedGroupInput): Promise<Group> => {
   const defaults = defaultGroupData()
   const currencyHref = data.currencyId
     ? data.currencyHref ?? accountingCurrencyHref(data.tenantId)
-    : data.currencyHref
+    : undefined
 
   const group = await db().group.create({
     data: {

--- a/social/test/mocks/seed.ts
+++ b/social/test/mocks/seed.ts
@@ -1,6 +1,7 @@
 import type { Category, File, Group, GroupAdminUser, Member, MemberUser, Post, User } from '../../src/generated/prisma/client'
 import { privilegedDb } from '../../src/server/multitenant'
 import prisma, { toNullableJsonInput } from '../../src/utils/prisma'
+import { accountingAccountHref, accountingCurrencyHref } from './accounting'
 import { toUuid } from './utils'
 
 let groupCounter = 0
@@ -145,6 +146,9 @@ export const seedUser = async (data: Partial<User> = {}): Promise<User> => {
 
 export const seedGroup = async (data: SeedGroupInput): Promise<Group> => {
   const defaults = defaultGroupData()
+  const currencyHref = data.currencyId
+    ? data.currencyHref ?? accountingCurrencyHref(data.tenantId)
+    : data.currencyHref
 
   const group = await db().group.create({
     data: {
@@ -163,6 +167,7 @@ export const seedGroup = async (data: SeedGroupInput): Promise<Group> => {
       settings: toNullableJsonInput(data.settings ?? defaults.settings),
       deleted: data.deleted,
       currencyId: data.currencyId,
+      currencyHref,
     },
   })
 
@@ -206,6 +211,10 @@ export const seedMember = async (data: SeedMemberInput): Promise<Member> => {
   const group = await getGroupByTenant(data.tenantId)
   const defaults = defaultMemberData()
   const {userId, ...input} = data
+  const accountId = data.accountId ? toUuid(data.accountId) : undefined
+  const accountHref = accountId
+    ? data.accountHref ?? accountingAccountHref(data.tenantId, accountId)
+    : data.accountHref
 
   const member = await db().member.create({
     data: {
@@ -217,7 +226,8 @@ export const seedMember = async (data: SeedMemberInput): Promise<Member> => {
       address: toNullableJsonInput(data.address),
       contacts: toNullableJsonInput(data.contacts),
       meta: toNullableJsonInput(data.meta),
-      accountId: data.accountId ? toUuid(data.accountId) : undefined,
+      accountId,
+      accountHref,
     },
   })
 


### PR DESCRIPTION
Summary
Capture Accounting’s links.self whenever Social synchronizes a currency or account. Persist that canonical link beside the resource ID and use it when serializing external JSON:API relationships. No public Accounting URL configuration is needed in Social.