### PR TITLE
DEF-004 Frontend External-Relationship Fix

### DIFF
--- a/app/src/components/SelectAccount.vue
+++ b/app/src/components/SelectAccount.vue
@@ -64,6 +64,7 @@ import { QSelect } from 'quasar';
 import { watchDebounced } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 import { normalizeAccountCode } from 'src/plugins/FormatCurrency';
+import { resolveRelationshipUrl } from 'src/store/relationships';
 
 type ExtendedAccount = Account & {member?: ExtendedMember & {group: Group}, currency?: Currency}
 type ExtendedMember = Member & {account?: ExtendedAccount }
@@ -162,7 +163,7 @@ const fetchExternalAccountByCode = async (search?: string) => {
     }
   } else {
     const code = normalizeAccountCode(search, group.value.currency)
-    const currencyUrl = group.value.relationships.currency.links.related
+    const currencyUrl = resolveRelationshipUrl(group.value.relationships.currency)
     const baseUrl = currencyUrl.replace('/currency', '')
     const accountUrl = `${baseUrl}/accounts?filter[code]=${code}`
 

--- a/app/src/components/SelectGroupExpansion.vue
+++ b/app/src/components/SelectGroupExpansion.vue
@@ -60,6 +60,7 @@ import ResourceCards from "../pages/ResourceCards.vue";
 import GroupHeader from "./GroupHeader.vue";
 import type { Ref } from "vue";
 import { computed, ref } from "vue";
+import { resolveRelationshipUrl } from "src/store/relationships";
 
 const props = defineProps<{
   modelValue: Group,
@@ -108,9 +109,7 @@ const checkShowGroup = (group: Group) => {
       // of resource-cards because we need to check also the related settings 
       // object and it is not possible to fetch related of external related objects.
       const checkSetting = async () => {
-        const url = (group.relationships.currency.data.meta && group.relationships.currency.data.meta.external) 
-          ? group.relationships.currency.data.meta.href
-          : group.relationships.currency.links.related
+        const url = resolveRelationshipUrl(group.relationships.currency)
 
         await store.dispatch("currencies/load", {
           url,

--- a/app/src/server/ApiSerializer.ts
+++ b/app/src/server/ApiSerializer.ts
@@ -46,8 +46,14 @@ export default class ApiSerializer extends JSONAPISerializer {
       // External relationships have associations but their relationships are deleted
       // from the hash in getHashForIncludedResource(), so this variable may be undefined.
       if (jsonRelationship) {
-        // Add meta.count field.
-        if ((this as any).isCollection(relationship)) {
+        if (this.isExternal(relationshipKey) && jsonRelationship.data) {
+          jsonRelationship.data.meta = {
+            external: true,
+            href: jsonRelationship.links.related
+          }
+          delete jsonRelationship.links
+        } else if ((this as any).isCollection(relationship)) {
+          // Add meta.count field.
           jsonRelationship.meta = {
             count: relationship.models.length
           }
@@ -75,11 +81,13 @@ export default class ApiSerializer extends JSONAPISerializer {
 
     if (this.isExternal(model.modelName)) {
       hash.included.forEach((resource: any) => {
+        const href = resource.links.self
         delete resource.attributes;
         delete resource.relationships;
+        delete resource.links;
         resource.meta = {
           external: true,
-          href: resource.links.self
+          href
         };
       });
       // Also dont follow the inclusion chain, since this is external resource and 

--- a/app/src/server/__tests__/Server.spec.ts
+++ b/app/src/server/__tests__/Server.spec.ts
@@ -94,20 +94,48 @@ describe("MirageJS Server", () => {
     const response = await fetch(`${urlSocial}/GRP0?include=currency`);
     const data = await response.json();
     const currency = data.included.find((resource: ResourceObject) => resource.type == "currencies");
-    expect(currency.meta.external).toBe(true);
-    expect(currency.links.self).toBe(`${urlAccounting}/GRP0/currency`);
-    expect(currency.attributes).toBeUndefined();
-    expect(currency.relationships).toBeUndefined();
+    expect(data.data.relationships.currency).toEqual({
+      data: {
+        type: "currencies",
+        id: currency.id,
+        meta: {
+          external: true,
+          href: `${urlAccounting}/GRP0/currency`
+        }
+      }
+    });
+    expect(currency).toEqual({
+      type: "currencies",
+      id: currency.id,
+      meta: {
+        external: true,
+        href: `${urlAccounting}/GRP0/currency`
+      }
+    });
   });
 
   it("includes account external resource", async() => {
     const response = await fetch(`${urlSocial}/GRP0/members?filter[code]=EmilianoLemke57&include=account`);
     const data = await response.json();
     const account = data.included.find((resource: ResourceObject) => resource.type == "accounts");
-    expect(account.meta.external).toBe(true);
-    expect(account.links.self).toBe(`${urlAccounting}/GRP0/accounts/${account.id}`);
-    expect(account.attributes).toBeUndefined();
-    expect(account.relationships).toBeUndefined();
+    expect(data.data[0].relationships.account).toEqual({
+      data: {
+        type: "accounts",
+        id: account.id,
+        meta: {
+          external: true,
+          href: `${urlAccounting}/GRP0/accounts/${account.id}`
+        }
+      }
+    });
+    expect(account).toEqual({
+      type: "accounts",
+      id: account.id,
+      meta: {
+        external: true,
+        href: `${urlAccounting}/GRP0/accounts/${account.id}`
+      }
+    });
   });
 
   it("loads user memberships from /users/:id/members", async () => {

--- a/app/src/store/me.ts
+++ b/app/src/store/me.ts
@@ -17,6 +17,7 @@ import type {
 
 import { config } from "src/utils/config";
 import { apiRequest } from "./request";
+import { resolveRelationshipUrl } from "./relationships";
 import { v4 as uuid } from "uuid";
 
 // Exported just for testing purposes.
@@ -83,7 +84,7 @@ async function loadUser(context: ActionContext<UserState, never>) {
   // A user requesting their first group does not have a membership yet.
   if (member) {
     // This is the currency URL from the Accounting API.
-    const currencyUrl = member.group.relationships.currency.links.related;
+    const currencyUrl = resolveRelationshipUrl(member.group.relationships.currency);
     // https://.../accounting/<GROUP>/currency
     
     // Get the accounting API URL from the currency URL and update it in the store. This is

--- a/app/src/store/model.ts
+++ b/app/src/store/model.ts
@@ -118,12 +118,23 @@ export interface RelatedLinkedCollection {
  * 
  * Contains linkage to the related resource.
  */
-export interface RelatedResource {
-  links: {
-    related: string;
-  },
-  data: ResourceIdentifierObject | ExternalResourceIdentifierObject
-}
+export type RelatedResource =
+  | {
+      links: {
+        related: string
+      }
+      data: ResourceIdentifierObject & {
+        meta?: Record<string, unknown> & {
+          external?: false
+        }
+      }
+    }
+  | {
+      links?: {
+        related: string
+      }
+      data: ExternalResourceIdentifierObject
+    }
 
 /**
  * Extension Resource Object for the inclusion of external relationships.
@@ -131,13 +142,7 @@ export interface RelatedResource {
  * Defined in External Relationship custom JSON:API profile:
  * https://github.com/komunitin/komunitin-api/blob/master/jsonapi-profiles/external.md
  */
-export interface ExternalResourceObject extends ResourceObject {
-  relationships?: undefined;
-  meta: {
-    external : true
-    href: string
-  }
-}
+export type ExternalResourceObject = ExternalResourceIdentifierObject
 
 /**
  * User model.

--- a/app/src/store/relationships.ts
+++ b/app/src/store/relationships.ts
@@ -1,0 +1,20 @@
+import type {
+  ExternalResourceIdentifierObject,
+  RelatedResource
+} from "./model"
+
+function isExternalRelationship(
+  relationship: RelatedResource
+): relationship is Extract<
+  RelatedResource,
+  { data: ExternalResourceIdentifierObject }
+> {
+  return relationship.data.meta?.external === true
+}
+
+export function resolveRelationshipUrl(relationship: RelatedResource) {
+  if (isExternalRelationship(relationship)) {
+    return relationship.data.meta.href
+  }
+  return relationship.links.related
+}


### PR DESCRIPTION
Summary
External resources must be fetched through data.meta.href; links.related remains the local API’s optional representation link. Social remains unchanged.