### PR TITLE
DEF-007: admin 0000 account provisioning

### DIFF
--- a/accounting/src/controller/base-controller.ts
+++ b/accounting/src/controller/base-controller.ts
@@ -89,8 +89,8 @@ export class BaseControllerImpl implements BasePublicService {
       throw badRequest(`Currency with code ${currency.code} already exists`)
     }
 
-    if (ctx.type !== "user" && ctx.type !== "system") {
-      throw unauthorized("Required user or system credentials")
+    if (ctx.type !== "user" && ctx.type !== "system" && ctx.type !== "superadmin") {
+      throw unauthorized("Required user, system or superadmin credentials")
     }
 
     // Create and save a currency key that will be used to encrypt all other keys

--- a/accounting/test/server/1.currency.api.test.ts
+++ b/accounting/test/server/1.currency.api.test.ts
@@ -11,6 +11,7 @@ describe('Currencies endpoints', async () => {
 
   const admin1 = userAuth("1")
   const admin2 = userAuth("2")
+  const superadmin = userAuth("superadmin", [Scope.Superadmin])
 
   const currencyPostBody = (attributes: Record<string, any>, user: string, settings: Record<string, any>) => {
     const userId = testUserId(user)
@@ -98,6 +99,42 @@ describe('Currencies endpoints', async () => {
     assert.equal(settings.attributes.defaultInitialCreditLimit, 1000000)
   })
 
+  await it('superadmin creates a currency and its administrator account', async () => {
+    const currency = currencyPostBody({code: "TES3"}, "3", {})
+    const currencyResponse = await t.api.post('/currencies', currency, superadmin)
+    assert.equal(currencyResponse.body.data.attributes.code, 'TES3')
+    assert.equal(currencyResponse.body.data.relationships.admins.data[0].id, testUserId("3"))
+
+    const accountResponse = await t.api.post('/TES3/accounts', {
+      data: {
+        type: "accounts",
+        attributes: {
+          code: "TES30000"
+        },
+        relationships: {
+          users: {
+            data: [{ type: "users", id: testUserId("3") }]
+          }
+        }
+      },
+      included: [{ type: "users", id: testUserId("3") }]
+    }, superadmin)
+
+    assert.equal(accountResponse.body.data.attributes.code, 'TES30000')
+    assert.equal(accountResponse.body.data.attributes.status, 'active')
+    assert.equal(accountResponse.body.data.attributes.balance, 0)
+    assert.equal(accountResponse.body.data.attributes.creditLimit, 1000)
+  })
+
+  await it('superadmin currency creation requires an explicit administrator', async () => {
+    const currency: any = currencyPostBody({code: "TES4"}, "4", {})
+    delete currency.data.relationships.admins
+    currency.included = currency.included.filter(({ type }: { type: string }) => type !== "users")
+
+    const response = await t.api.post('/currencies', currency, superadmin, 400)
+    assert.equal(response.body.errors[0].detail, 'Admin user must be provided explicitly or as logged in user')
+  })
+
   await it('repeated code', async () => badPost({code: "TES1"}))
   await it('incorrect code', async () => badPost({code: "EUR", rate: undefined}))
   await it('missing rate', async () => badPost({code: "ERRO", rate: undefined}))
@@ -138,9 +175,10 @@ describe('Currencies endpoints', async () => {
   await it('list currencies', async () => {
     const response = await t.api.get('/currencies')
     assert(Array.isArray(response.body.data))
-    assert.equal(response.body.data.length,2)
+    assert.equal(response.body.data.length,3)
     assert.equal(response.body.data[0].attributes.code, 'TES1')
     assert.equal(response.body.data[1].attributes.code, 'TES2')
+    assert.equal(response.body.data[2].attributes.code, 'TES3')
   })
   
   // public endpoint

--- a/app/src/pages/members/MemberPageHeader.vue
+++ b/app/src/pages/members/MemberPageHeader.vue
@@ -152,10 +152,11 @@ export default defineComponent({
   },
   computed: {
     memberTypeLabel(): string {
-      const labels: { [key: string]: string } = {
+      const labels: Record<Member["attributes"]["type"], string> = {
         personal: this.$t("personalAccount") as string,
         business: this.$t("businessAccount") as string,
-        organization: this.$t("organizationAccount") as string
+        organization: this.$t("organizationAccount") as string,
+        public: this.$t("publicAccount") as string
       };
       return labels[(this.member as Member).attributes.type];
     }

--- a/app/src/store/model.ts
+++ b/app/src/store/model.ts
@@ -283,7 +283,7 @@ export interface Member extends ResourceObject {
     code: string;
     access: Access;
     name: string;
-    type: "personal" | "business" | "organization";
+    type: "personal" | "business" | "organization" | "public";
     status: MemberStatus;
     description: string;
     image: ImageObject | null;

--- a/auth/src/oidc/clients.ts
+++ b/auth/src/oidc/clients.ts
@@ -37,6 +37,16 @@ const socialScopes = [
 
 const publisherScopes = ['notifications:write'] as const
 
+// The allowed scopes for token exchange in each client.
+export const tokenExchangeScopes: Record<string, readonly string[]> = {
+  [clientIds.notifications]: notificationsScopes,
+  [clientIds.social]: [
+    'accounting:read',
+    'accounting:write',
+    SUPERADMIN_SCOPE,
+  ],
+}
+
 const scopeString = (scopes: readonly string[]) => scopes.join(' ')
 
 // oidc-provider requires redirect/response metadata even for token-only clients.

--- a/auth/src/oidc/provider.ts
+++ b/auth/src/oidc/provider.ts
@@ -10,7 +10,7 @@ import Provider, {
 import { config } from '../config'
 import { adapterFactory } from './adapter'
 import { findAccount, authenticate } from './account'
-import { apiScopes, clients, SUPERADMIN_SCOPE } from './clients'
+import { apiScopes, clients, SUPERADMIN_SCOPE, tokenExchangeScopes } from './clients'
 import { verifySignedToken } from './token-verifier'
 import type { Jwks } from './jwks'
 import { isUuid } from '../utils/uuid'
@@ -82,16 +82,21 @@ const clientScopeSet = (client: Client) => {
   return client.scope ? new Set(splitScope(client.scope)) : allowedScopes
 }
 
+const tokenExchangeScopeSet = (client: Client) => {
+  const scopes = tokenExchangeScopes[client.clientId]
+  return scopes ? new Set(scopes) : clientScopeSet(client)
+}
+
 const ensureClientScopesAllowed = (
   ctx: KoaContextWithOIDC,
   client: Client,
   requestedScopes: string[],
+  clientScopes = clientScopeSet(client),
 ) => {
   if (!client.scope) {
     return
   }
 
-  const clientScopes = clientScopeSet(client)
   const disallowedScope = requestedScopes.find((scope) => allowedScopes.has(scope) && !clientScopes.has(scope))
 
   if (disallowedScope) {
@@ -102,8 +107,11 @@ const ensureClientScopesAllowed = (
   }
 }
 
-const filterAllowedScopes = (scopes: string[], client: Client) => {
-  const clientScopes = clientScopeSet(client)
+const filterAllowedScopes = (
+  scopes: string[],
+  client: Client,
+  clientScopes = clientScopeSet(client),
+) => {
   return [...new Set(scopes.filter((scope) => allowedScopes.has(scope) && clientScopes.has(scope)))]
 }
 
@@ -303,12 +311,14 @@ export async function createProvider(jwks: Jwks) {
       const subjectScope = typeof tokenPayload.scope === 'string' ? tokenPayload.scope : ''
       const requestedScopes = getRequestedScopes(scope, splitScope(subjectScope))
       const subjectScopes = new Set(splitScope(subjectScope))
+      const exchangeScopes = tokenExchangeScopeSet(client)
       if (scope) {
-        ensureClientScopesAllowed(ctx, client, requestedScopes)
+        ensureClientScopesAllowed(ctx, client, requestedScopes, exchangeScopes)
       }
       const grantedScopes = filterAllowedScopes(
         requestedScopes.filter((candidate) => subjectScopes.has(candidate)),
         client,
+        exchangeScopes,
       )
 
       if (requestedScopes.length > 0 && grantedScopes.length === 0) {

--- a/auth/test/auth.test.ts
+++ b/auth/test/auth.test.ts
@@ -1228,6 +1228,105 @@ describe('Auth Service Integration Tests', () => {
     assert.strictEqual(decoded.email, undefined)
   })
 
+  test('POST /token lets Social preserve superadmin only through user token exchange', async () => {
+    const userId = '25252525-2525-4525-8525-252525252525'
+    await prisma.user.create({
+      data: {
+        id: userId,
+        email: 'superadmin@test.com',
+        passwordHash: await hashPassword('password123'),
+        emailVerified: true,
+        status: UserStatus.Active,
+      },
+    })
+
+    const tokenRes = await request(app)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'password',
+        client_id: 'komunitin-app',
+        username: 'superadmin@test.com',
+        password: 'password123',
+        scope: 'accounting:write superadmin',
+      })
+      .expect(200)
+
+    const exchangeRes = await request(app)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        client_id: 'komunitin-social',
+        client_secret: 'komunitin-social-secret',
+        subject_token: tokenRes.body.access_token,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        scope: 'superadmin',
+      })
+      .expect(200)
+
+    assertAccessToken(exchangeRes.body.access_token, {
+      subject: userId,
+      clientId: 'komunitin-social',
+      scope: 'superadmin',
+    })
+
+    const credentialsRes = await request(app)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'client_credentials',
+        client_id: 'komunitin-social',
+        client_secret: 'komunitin-social-secret',
+        scope: 'superadmin',
+      })
+      .expect(400)
+
+    assert.strictEqual(credentialsRes.body.error, 'invalid_scope')
+  })
+
+  test('POST /token does not delegate superadmin from a normal subject', async () => {
+    const userId = '28282828-2828-4828-8828-282828282828'
+    await prisma.user.create({
+      data: {
+        id: userId,
+        email: 'normal-delegation@example.org',
+        passwordHash: await hashPassword('password123'),
+        emailVerified: true,
+        status: UserStatus.Active,
+      },
+    })
+
+    const tokenRes = await request(app)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'password',
+        client_id: 'komunitin-app',
+        username: 'normal-delegation@example.org',
+        password: 'password123',
+        scope: 'accounting:write superadmin',
+      })
+      .expect(200)
+
+    assert.strictEqual(tokenRes.body.scope, 'accounting:write')
+
+    const exchangeRes = await request(app)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        client_id: 'komunitin-social',
+        client_secret: 'komunitin-social-secret',
+        subject_token: tokenRes.body.access_token,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        scope: 'superadmin',
+      })
+      .expect(400)
+
+    assert.strictEqual(exchangeRes.body.error, 'invalid_scope')
+  })
+
   test('POST /token with Token Exchange does not escalate scopes', async () => {
     const userId = '26262626-2626-2626-2626-262626262626'
     const passwordHash = await hashPassword('password123')
@@ -1271,7 +1370,7 @@ describe('Auth Service Integration Tests', () => {
     assert.strictEqual(decoded.email, undefined)
   })
 
-  test('POST /token with Token Exchange rejects scopes outside the client allowlist', async () => {
+  test('POST /token does not exchange Social notification publishing scope', async () => {
     const userId = '27272727-2727-2727-2727-272727272727'
     const passwordHash = await hashPassword('password123')
     await prisma.user.create({
@@ -1292,7 +1391,7 @@ describe('Auth Service Integration Tests', () => {
         client_id: 'komunitin-app',
         username: 'cross-service@example.org',
         password: 'password123',
-        scope: 'social:read',
+        scope: 'notifications:write',
       })
       .expect(200)
 
@@ -1305,7 +1404,7 @@ describe('Auth Service Integration Tests', () => {
         client_secret: 'komunitin-social-secret',
         subject_token: tokenRes.body.access_token,
         subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-        scope: 'social:read',
+        scope: 'notifications:write',
       })
       .expect(400)
 

--- a/social/src/clients/accounting.ts
+++ b/social/src/clients/accounting.ts
@@ -95,9 +95,11 @@ class AccountingClient {
     init: RequestInit,
     options: RequestOptions = {},
   ): Promise<JsonApiDoc | undefined> {
-    const scope = !init.method || init.method === 'GET'
-      ? Scope.AccountingRead
-      : Scope.AccountingWrite
+    const scope = this.ctx.isSuperadmin
+      ? Scope.Superadmin
+      : !init.method || init.method === 'GET'
+        ? Scope.AccountingRead
+        : Scope.AccountingWrite
     const response = await fetchWithAuth(
       accountingUrl(path),
       {

--- a/social/src/clients/auth.ts
+++ b/social/src/clients/auth.ts
@@ -6,8 +6,11 @@ import { AsyncCache, type CacheValue } from '../utils/cache'
 import { badRequest, internalError } from '../utils/error'
 import { fetchWithAuth, fetchWithRetry } from './utils'
 
-type AccountingScope = typeof Scope.AccountingRead | typeof Scope.AccountingWrite
-type ServiceScope = AccountingScope | typeof Scope.NotificationsWrite
+type AccountingTokenScope =
+  | typeof Scope.AccountingRead
+  | typeof Scope.AccountingWrite
+  | typeof Scope.Superadmin
+type TokenScope = AccountingTokenScope | typeof Scope.NotificationsWrite
 
 type TokenResponse = {
   access_token?: unknown
@@ -20,7 +23,7 @@ type TokenRequestParameters = Record<string, string> & {
   grant_type:
     | 'client_credentials'
     | 'urn:ietf:params:oauth:grant-type:token-exchange'
-  scope: ServiceScope
+  scope: TokenScope
 }
 
 const redeemedUnsubscribeTokenSchema = z.object({
@@ -50,7 +53,7 @@ const getCachedToken = async (
   return cache.getOrLoad(key, load)
 }
 
-const getCacheKey = (subjectToken: string, scope: AccountingScope): string => {
+const getCacheKey = (subjectToken: string, scope: AccountingTokenScope): string => {
   return createHash('sha256')
     .update(subjectToken)
     .update('\0')
@@ -97,7 +100,7 @@ const requestToken = async (parameters: TokenRequestParameters): Promise<CacheVa
 
 const requestAccountingToken = async (
   subjectToken: string,
-  scope: AccountingScope,
+  scope: AccountingTokenScope,
 ): Promise<CacheValue<string>> => {
   return requestToken({
     grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
@@ -175,7 +178,7 @@ export const redeemUnsubscribeToken = async (token: string): Promise<RedeemedUns
  */
 export const exchangeAccountingToken = async (
   subjectToken: string,
-  scope: AccountingScope,
+  scope: AccountingTokenScope,
   forceRefresh = false,
 ): Promise<string> => {
   const key = getCacheKey(subjectToken, scope)

--- a/social/src/features/groups/service.ts
+++ b/social/src/features/groups/service.ts
@@ -2,7 +2,8 @@ import { InputJsonObject } from '@prisma/client/runtime/client'
 import { Group as DbGroupRaw, GroupAdminUser, Prisma } from '../../generated/prisma/client'
 import { GroupUpdateInput } from '../../generated/prisma/models'
 import { AuthContext, OptionalAuthContext } from '../../server/context'
-import { createAccountingClient, Currency } from '../../clients/accounting'
+import { createAccountingClient } from '../../clients/accounting'
+import type { Account, Currency } from '../../clients/accounting'
 import { privilegedDb, tenantDb } from '../../server/multitenant'
 import { type CollectionResult, reorderByIds } from '../../server/query'
 import type { CollectionParams } from '../../server/request'
@@ -15,6 +16,7 @@ import { findGroupIds } from './sql'
 import type { CreateGroupInput, Group, GroupMeta, SerializableGroup } from './types'
 import { createNotificationsClient } from '../../clients/notifications'
 import { findUserMembers } from '../users/member-query'
+import { syncAccountStatus } from '../members/accounting'
 
 type WithAddressAndCoords = Pick<DbGroup, 'address' | 'latitude' | 'longitude'>
 
@@ -69,7 +71,7 @@ export const enrichGroups = async (
     }
     return userMemberGroups
   }
-  
+
   const isMember = (group: Group) => async () => {
     const userMemberGroups = await getUserMemberGroups()
     return userMemberGroups.has(group.id)
@@ -311,6 +313,41 @@ const syncCurrencyStatus = async (ctx: AuthContext, group: Group, status: Curren
   return currency
 }
 
+type AdminMemberCandidate = {
+  accountId?: string | null
+  adminUserId: string
+  code: string
+  memberId?: string
+}
+
+type AdminMemberProvision = AdminMemberCandidate & {
+  account: Account
+}
+
+const getAdminMemberCandidate = async (group: Group): Promise<AdminMemberCandidate> => {
+  const adminUserId = group.admins[0].id
+  const code = `${group.code}0000`
+  const db = tenantDb(prisma, group.code)
+  const member = await db.member.findFirst({
+    where: { code },
+    include: { users: true },
+  })
+
+  if (member && (
+    member.deleted
+    || !member.users.some(({ userId }) => userId === adminUserId)
+  )) {
+    throw badRequest(`Reserved administrator member ${code} is already in use`)
+  }
+
+  return {
+    adminUserId,
+    accountId: member?.accountId,
+    code,
+    memberId: member?.id,
+  }
+}
+
 export const patchGroupByCode = async (ctx: AuthContext, code: string, attributes: PatchGroupAttributes): Promise<SerializableGroup> => {
   const group = await getGroupByCode(ctx, code)
 
@@ -325,7 +362,8 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
     ...rest,
     image: toNullableJsonInput(image),
   }
-  let notifyGroupActivated = false
+  const groupName = attributes.name ?? group.name
+  const groupAccess = attributes.access ?? group.access
 
   if (meta !== undefined) {
     if (group.status !== 'pending') {
@@ -341,6 +379,9 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
   }
 
   // Status transition
+  let adminMemberCandidate: AdminMemberCandidate | undefined
+  let adminMemberProvision: AdminMemberProvision | undefined
+
   if (status !== undefined && status !== group.status) {
     if (status === 'active' && group.status === 'disabled'
       || status === 'disabled' && group.status === 'active') {
@@ -350,6 +391,7 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
       if (!ctx.isSuperadmin) {
         throw forbidden('Only superadmins can activate groups')
       }
+      adminMemberCandidate = await getAdminMemberCandidate(group)
     } else {
       throw badRequest(`Invalid status transition from ${group.status} to ${status}`)
     }
@@ -362,8 +404,17 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
       data.currencyHref = currency.href
     }
 
-    if (group.status === 'pending' && status === 'active') {
-      notifyGroupActivated = true
+    // If the group is being activated
+    if (adminMemberCandidate) {
+      const account = await syncAccountStatus(ctx, {
+        accountId: adminMemberCandidate.accountId,
+        code: adminMemberCandidate.code,
+        userIds: [adminMemberCandidate.adminUserId],
+      }, getCurrencyCode(group), 'active')
+      adminMemberProvision = {
+        ...adminMemberCandidate,
+        account,
+      }
       // Clear the meta field on activation.
       data.meta = Prisma.DbNull
     }
@@ -372,12 +423,59 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
   }
   
   const db = tenantDb(prisma, code)
-  const dbUpdated = await db.group.update({
-    where: { id: group.id },
-    data,
-    include: {
-      admins: true,
+  const dbUpdated = await db.transaction(async (tx) => {
+    const updatedGroup = await tx.group.update({
+      where: { id: group.id },
+      data,
+      include: {
+        admins: true,
+      },
+    })
+
+    if (adminMemberProvision) {
+      const memberData = {
+        name: groupName,
+        status: 'active',
+        access: groupAccess,
+        accountId: adminMemberProvision.account.id,
+        accountHref: adminMemberProvision.account.href,
+      }
+      const member = adminMemberProvision.memberId
+        ? await tx.member.update({
+            where: { id: adminMemberProvision.memberId },
+            data: memberData,
+          })
+        : await tx.member.create({
+            data: {
+              ...memberData,
+              code: adminMemberProvision.code,
+              type: 'public',
+              description: '',
+              contacts: [],
+              groupId: group.id,
+            },
+          })
+
+      await tx.memberUser.upsert({
+        where: {
+          memberId_userId: {
+            memberId: member.id,
+            userId: adminMemberProvision.adminUserId,
+          },
+        },
+        create: {
+          tenantId: code,
+          memberId: member.id,
+          userId: adminMemberProvision.adminUserId,
+          role: 'admin',
+        },
+        update: {
+          role: 'admin',
+        },
+      })
     }
+
+    return updatedGroup
   })
 
   if (attributes.image !== undefined) {
@@ -386,7 +484,7 @@ export const patchGroupByCode = async (ctx: AuthContext, code: string, attribute
 
   const updated = await enrichGroup(ctx, toGroup(dbUpdated))
 
-  if (notifyGroupActivated) {
+  if (adminMemberCandidate) {
     const notifications = createNotificationsClient(ctx)
     await notifications.notifyGroupActivated(updated)
   }

--- a/social/src/features/members/accounting.ts
+++ b/social/src/features/members/accounting.ts
@@ -1,0 +1,48 @@
+import { type Account, createAccountingClient } from '../../clients/accounting'
+import type { AuthContext } from '../../server/context'
+
+type AccountSyncInput = {
+  accountId?: string | null
+  code: string
+  userIds: string[]
+}
+
+type AccountingClient = ReturnType<typeof createAccountingClient>
+
+const findAccount = async (
+  accounting: AccountingClient,
+  member: AccountSyncInput,
+  currencyCode: string,
+): Promise<Account | undefined> => {
+  if (member.accountId) {
+    return accounting.getAccount(currencyCode, member.accountId)
+  }
+
+  // Adopt an account left by a previously interrupted cross-service operation.
+  return accounting.findAccountByCode(currencyCode, member.code)
+}
+
+/**
+ * Create or update the Accounting account corresponding to a Social member.
+ */
+export const syncAccountStatus = async (
+  ctx: AuthContext,
+  member: AccountSyncInput,
+  currencyCode: string,
+  status: Account['status'],
+): Promise<Account> => {
+  const accounting = createAccountingClient(ctx)
+  let account = await findAccount(accounting, member, currencyCode)
+
+  if (!account) {
+    account = await accounting.createAccount(currencyCode, {
+      code: member.code,
+    }, member.userIds)
+  }
+
+  if (account.status !== status) {
+    account = await accounting.updateAccount(currencyCode, account.id, { status })
+  }
+
+  return account
+}

--- a/social/src/features/members/schema.ts
+++ b/social/src/features/members/schema.ts
@@ -13,7 +13,7 @@ import {
 
 export type { Address, Contact, Location }
 
-export const memberTypeSchema = z.enum(['personal', 'business', 'organization'])
+export const memberTypeSchema = z.enum(['personal', 'business', 'organization', 'public'])
 export type MemberType = z.infer<typeof memberTypeSchema>
 
 export const memberStatusSchema = z.enum(['draft', 'pending', 'active', 'disabled', 'suspended', 'deleted'])

--- a/social/src/features/members/service.ts
+++ b/social/src/features/members/service.ts
@@ -1,4 +1,4 @@
-import { Account, createAccountingClient } from '../../clients/accounting'
+import { createAccountingClient } from '../../clients/accounting'
 import { Prisma, type Member as DbMemberRecord } from '../../generated/prisma/client'
 import type { AuthContext, OptionalAuthContext } from '../../server/context'
 import { tenantDb } from '../../server/multitenant'
@@ -14,6 +14,7 @@ import type { CreateMemberInput, Member, PatchMemberInput, SerializableMember } 
 import { createNotificationsClient } from '../../clients/notifications'
 import { findPostRelationshipCounts } from '../posts/sql'
 import type { PostRelationshipMeta } from '../posts/types'
+import { syncAccountStatus } from './accounting'
 
 const getMemberLoad = (params: ResourceParams) => ({
   group: hasInclude(params, 'group'),
@@ -161,43 +162,6 @@ const getMemberUserIds = async (member: Pick<Member, 'id' | 'tenantId'>): Promis
   })
 
   return [...new Set(relations.map((relation) => relation.userId))]
-}
-
-type AccountingClient = ReturnType<typeof createAccountingClient>
-
-const findMemberAccount = async (accounting: AccountingClient, member: Member, currencyCode: string): Promise<Account | undefined> => {
-  if (member.accountId) {
-    return await accounting.getAccount(currencyCode, member.accountId)
-  }
-
-  // Just in case the member has an account but the accountId is not set, 
-  // try to find it by code before creating a new one.
-  return await accounting.findAccountByCode(currencyCode, member.code)
-}
-
-/**
- * Synchronize the account status from the accounting service to the provided status.
- * 
- * If the member does not have an account, one will be created. If the account exists 
- * but has a different status, it will be updated.
- */
-const syncAccountStatus = async (ctx: AuthContext, member: Member, currencyCode: string, status: Account["status"]): Promise<Account> => {
-  const accounting = createAccountingClient(ctx)
-  let account = await findMemberAccount(accounting, member, currencyCode)
-
-  if (!account) {
-    const users = await getMemberUserIds(member)
-    account = await accounting.createAccount(currencyCode, {
-      code: member.code,
-    }, users)
-  }
-
-  // Update account status if needed.
-  if (account.status !== status) {
-    account = await accounting.updateAccount(currencyCode, account.id, { status })
-  }
-
-  return account
 }
 
 /**
@@ -371,7 +335,11 @@ export const patchMember = async (
 
     if (to === 'active' || to === 'disabled' || to === 'suspended') {
       const currencyCode = getCurrencyCode(group)
-      const account = await syncAccountStatus(ctx, member, currencyCode, to)
+      const account = await syncAccountStatus(ctx, {
+        accountId: member.accountId,
+        code: member.code,
+        userIds: await getMemberUserIds(member),
+      }, currencyCode, to)
       data.accountId = account.id
       data.accountHref = account.href
     }

--- a/social/test/group.test.ts
+++ b/social/test/group.test.ts
@@ -5,14 +5,16 @@ import { tenantDb } from '../src/server/multitenant'
 import prisma from '../src/utils/prisma'
 import { Scope } from '../src/server/context'
 import { auth, serviceAuth } from './mocks/auth'
-import { accountingCurrencyHref } from './mocks/accounting'
+import { accountingAccountHref, accountingCurrencyHref } from './mocks/accounting'
 import {
   getAccountingRequests,
   getAccountingRequestPaths,
   getAuthTokenRequests,
   getNotificationsEvents,
   resetMockState,
+  seedAccountingAccount,
   seedAccountingCurrency,
+  setAccountingAccountCreateStatus,
   setAccountingCurrencyDeleteStatus,
 } from './mocks/handlers'
 import { resetDb, seedCategory, seedGroup, seedGroupAdmin, seedMember } from './mocks/seed'
@@ -1046,15 +1048,43 @@ describe('Groups endpoints', () => {
 
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
-      ['GET /activate-group/currency', 'POST /currencies'],
+      [
+        'GET /activate-group/currency',
+        'POST /currencies',
+        'GET /activate-group/accounts',
+        'POST /activate-group/accounts',
+      ],
     )
 
-    const db = tenantDb(prisma, 'activate-group')
-    const group = await db.group.findFirstOrThrow()
-    assert.strictEqual(group.status, 'active')
-    assert.strictEqual(group.currencyId, res.body.data.relationships.currency.data.id)
-    assert.strictEqual(group.currencyHref, currencyHref)
-    assert.strictEqual(group.meta, null)
+    const groupRes = await request(app)
+      .get('/activate-group')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(groupRes.body.data.attributes.status, 'active')
+    assert.strictEqual(groupRes.body.data.attributes.meta, null)
+    assert.strictEqual(
+      groupRes.body.data.relationships.currency.data.id,
+      res.body.data.relationships.currency.data.id,
+    )
+    assert.strictEqual(groupRes.body.data.relationships.currency.data.meta.href, currencyHref)
+
+    const membersRes = await request(app)
+      .get('/activate-group/members?filter[code]=activate-group0000&include=account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(membersRes.body.data.length, 1)
+    const member = membersRes.body.data[0]
+    assert.strictEqual(member.attributes.code, 'activate-group0000')
+    assert.strictEqual(member.attributes.name, res.body.data.attributes.name)
+    assert.strictEqual(member.attributes.status, 'active')
+    assert.ok(member.attributes.accountId)
+    assert.strictEqual(member.relationships.account.data.type, 'accounts')
+    assert.strictEqual(member.relationships.account.data.id, member.attributes.accountId)
+    assert.strictEqual(member.relationships.account.data.meta.external, true)
+    assert.strictEqual(
+      member.relationships.account.data.meta.href,
+      accountingAccountHref('activate-group', member.attributes.accountId),
+    )
 
     const events = getNotificationsEvents() as any[]
     assert.strictEqual(events.length, 1)
@@ -1062,7 +1092,7 @@ describe('Groups endpoints', () => {
     assert.strictEqual(events[0].data.attributes.code, 'activate-group')
   })
 
-  test('PATCH /:code adopts existing accounting currency without creating a new one', async () => {
+  test('PATCH /:code adopts existing accounting currency and administrator account', async () => {
     const superadmin = await auth('group-adopt-superadmin', undefined, Scope.Superadmin)
     const currency = seedAccountingCurrency('adopt-group')
 
@@ -1079,6 +1109,13 @@ describe('Groups endpoints', () => {
         },
       },
     })
+    const db = tenantDb(prisma, 'adopt-group')
+    const admin = await db.groupAdminUser.findFirstOrThrow()
+    const account = seedAccountingAccount(
+      'adopt-group',
+      'adopt-group0000',
+      [admin.userId],
+    )
 
     const res = await request(app)
       .patch('/adopt-group')
@@ -1096,26 +1133,197 @@ describe('Groups endpoints', () => {
     assert.strictEqual(res.body.data.relationships.currency.data.id, currency.id)
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
-      ['GET /adopt-group/currency'],
+      ['GET /adopt-group/currency', 'GET /adopt-group/accounts'],
     )
     assert.deepStrictEqual(getAuthTokenRequests(), [{
       clientId: 'komunitin-social',
       grantType: 'urn:ietf:params:oauth:grant-type:token-exchange',
-      scope: Scope.AccountingRead,
+      scope: Scope.Superadmin,
       subjectToken: superadmin.token,
     }])
     assert.strictEqual(
       getAccountingRequests()[0].authorization,
-      'Bearer exchanged-accounting-read',
+      'Bearer exchanged-superadmin',
     )
 
-    const db = tenantDb(prisma, 'adopt-group')
-    const group = await db.group.findFirstOrThrow()
-    assert.strictEqual(group.currencyId, currency.id)
-    assert.strictEqual(group.currencyHref, currency.href)
     assert.strictEqual(res.body.data.relationships.currency.data.meta.href, currency.href)
-    assert.strictEqual(group.meta, null)
     assert.strictEqual(res.body.data.attributes.meta, null)
+    const groupRes = await request(app)
+      .get('/adopt-group')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(groupRes.body.data.relationships.currency.data.id, currency.id)
+    assert.strictEqual(groupRes.body.data.relationships.currency.data.meta.href, currency.href)
+    assert.strictEqual(groupRes.body.data.attributes.meta, null)
+
+    const membersRes = await request(app)
+      .get('/adopt-group/members?filter[code]=adopt-group0000&include=account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(membersRes.body.data.length, 1)
+    assert.strictEqual(membersRes.body.data[0].attributes.status, 'active')
+    assert.strictEqual(membersRes.body.data[0].attributes.accountId, account.id)
+    assert.strictEqual(membersRes.body.data[0].relationships.account.data.id, account.id)
+    assert.strictEqual(membersRes.body.data[0].relationships.account.data.meta.href, account.href)
+  })
+
+  test('PATCH /:code adopts a pending administrator 0000 member and uses the group name', async () => {
+    const superadmin = await auth('group-member-adopt-superadmin', undefined, Scope.Superadmin)
+    const group = await seedGroup({
+      tenantId: 'adopt-admin-member',
+      name: 'Adopted Community',
+      status: 'pending',
+      access: 'public',
+      meta: {
+        request: {
+          currency: testCurrencyAttributes,
+        },
+      },
+    })
+    const db = tenantDb(prisma, 'adopt-admin-member')
+    const admin = await db.groupAdminUser.findFirstOrThrow()
+    const existing = await seedMember({
+      tenantId: 'adopt-admin-member',
+      code: 'adopt-admin-member0000',
+      name: 'Old administrator name',
+      status: 'pending',
+      userId: admin.userId,
+    })
+
+    await request(app)
+      .patch('/adopt-admin-member')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .send({
+        data: {
+          type: 'groups',
+          attributes: {
+            status: 'active',
+          },
+        },
+      })
+      .expect(200)
+
+    const membersRes = await request(app)
+      .get('/adopt-admin-member/members?filter[code]=adopt-admin-member0000&include=account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(membersRes.body.data.length, 1)
+    const member = membersRes.body.data[0]
+    assert.strictEqual(member.id, existing.id)
+    assert.strictEqual(member.attributes.name, group.name)
+    assert.strictEqual(member.attributes.status, 'active')
+    assert.ok(member.attributes.accountId)
+    assert.strictEqual(member.relationships.account.data.id, member.attributes.accountId)
+    assert.strictEqual(member.relationships.account.data.meta.external, true)
+    assert.strictEqual(getNotificationsEvents().length, 1)
+    assert.strictEqual((getNotificationsEvents()[0] as any).data.attributes.name, 'GroupActivated')
+  })
+
+  test('PATCH /:code rejects a conflicting reserved administrator member before accounting calls', async () => {
+    const superadmin = await auth('group-member-conflict-superadmin', undefined, Scope.Superadmin)
+    await seedGroup({
+      tenantId: 'conflicting-admin-member',
+      status: 'pending',
+      access: 'public',
+      meta: {
+        request: {
+          currency: testCurrencyAttributes,
+        },
+      },
+    })
+    await seedMember({
+      tenantId: 'conflicting-admin-member',
+      code: 'conflicting-admin-member0000',
+      status: 'pending',
+      userId: toUuid('different-reserved-member-owner'),
+    })
+
+    const res = await request(app)
+      .patch('/conflicting-admin-member')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .send({
+        data: {
+          type: 'groups',
+          attributes: {
+            status: 'active',
+          },
+        },
+      })
+      .expect(400)
+
+    assert.strictEqual(
+      res.body.errors[0].detail,
+      'Reserved administrator member conflicting-admin-member0000 is already in use',
+    )
+    assert.deepStrictEqual(getAccountingRequestPaths(), [])
+    const groupRes = await request(app)
+      .get('/conflicting-admin-member')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(groupRes.body.data.attributes.status, 'pending')
+  })
+
+  test('PATCH /:code leaves Social pending after account creation failure and succeeds on retry', async () => {
+    const superadmin = await auth('group-account-retry-superadmin', undefined, Scope.Superadmin)
+    await seedGroup({
+      tenantId: 'retry-admin-account',
+      status: 'pending',
+      access: 'public',
+      meta: {
+        request: {
+          currency: testCurrencyAttributes,
+        },
+      },
+    })
+    setAccountingAccountCreateStatus(500)
+
+    await request(app)
+      .patch('/retry-admin-account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .send({
+        data: {
+          type: 'groups',
+          attributes: {
+            status: 'active',
+          },
+        },
+      })
+      .expect(500)
+
+    const failedGroupRes = await request(app)
+      .get('/retry-admin-account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(failedGroupRes.body.data.attributes.status, 'pending')
+    const failedMembersRes = await request(app)
+      .get('/retry-admin-account/members?filter[code]=retry-admin-account0000')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(failedMembersRes.body.data.length, 0)
+    assert.strictEqual(getNotificationsEvents().length, 0)
+
+    setAccountingAccountCreateStatus(201)
+    const activated = await request(app)
+      .patch('/retry-admin-account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .send({
+        data: {
+          type: 'groups',
+          attributes: {
+            status: 'active',
+          },
+        },
+      })
+      .expect(200)
+
+    assert.strictEqual(activated.body.data.attributes.status, 'active')
+    const membersRes = await request(app)
+      .get('/retry-admin-account/members?filter[code]=retry-admin-account0000&include=account')
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .expect(200)
+    assert.strictEqual(membersRes.body.data.length, 1)
+    assert.strictEqual(membersRes.body.data[0].attributes.status, 'active')
+    assert.ok(membersRes.body.data[0].relationships.account.data.id)
   })
 
   test('PATCH /:code allows group admin to disable and reactivate with accounting sync', async () => {

--- a/social/test/member.test.ts
+++ b/social/test/member.test.ts
@@ -3,10 +3,12 @@ import assert from 'node:assert'
 import request from 'supertest'
 import { tenantDb } from '../src/server/multitenant'
 import prisma from '../src/utils/prisma'
+import { Scope } from '../src/server/context'
 import { auth, serviceAuth } from './mocks/auth'
 import { accountingAccountHref } from './mocks/accounting'
 import {
   getAccountingRequestPaths,
+  getAuthTokenRequests,
   getNotificationsEvents,
   resetMockState,
   seedAccountingAccount,
@@ -545,15 +547,80 @@ describe('Members endpoints', () => {
     assert.strictEqual(approved.body.data.relationships.account.data.meta.external, true)
     const accountHref = accountingAccountHref(currency.code, approved.body.data.attributes.accountId)
     assert.strictEqual(approved.body.data.relationships.account.data.meta.href, accountHref)
-    
+
     assert.deepStrictEqual(
       getAccountingRequestPaths(),
       [`GET /${currency.code}/accounts`, `POST /${currency.code}/accounts`],
     )
+    assert.deepStrictEqual(getAuthTokenRequests(), [
+      {
+        clientId: 'komunitin-social',
+        grantType: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        scope: Scope.AccountingRead,
+        subjectToken: admin.token,
+      },
+      {
+        clientId: 'komunitin-social',
+        grantType: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        scope: Scope.AccountingWrite,
+        subjectToken: admin.token,
+      },
+    ])
     const events = getNotificationsEvents() as any[]
     assert.strictEqual(events.length, 1)
     assert.strictEqual(events[0].data.attributes.name, 'MemberJoined')
     assert.strictEqual(events[0].data.attributes.code, 'members-approve')
+  })
+
+  test('PATCH /:code/members/:member lets superadmin create the Accounting account', async () => {
+    const currency = seedAccountingCurrency('members-superadmin-approve')
+    await seedGroup({
+      tenantId: 'members-superadmin-approve',
+      status: 'active',
+      access: 'public',
+      currencyId: currency.id,
+    })
+    const owner = await auth('member-superadmin-approve-owner')
+    const superadmin = await auth(
+      'member-superadmin-approver',
+      undefined,
+      Scope.Superadmin,
+    )
+    const member = await seedMember({
+      tenantId: 'members-superadmin-approve',
+      code: 'members-superadmin-approve0001',
+      status: 'pending',
+      userId: owner.id,
+    })
+
+    const approved = await request(app)
+      .patch(`/members-superadmin-approve/members/${member.id}`)
+      .set('Authorization', `Bearer ${superadmin.token}`)
+      .send({
+        data: {
+          type: 'members',
+          attributes: {
+            status: 'active',
+          },
+        },
+      })
+      .expect(200)
+
+    assert.strictEqual(approved.body.data.attributes.status, 'active')
+    assert.ok(approved.body.data.attributes.accountId)
+    assert.deepStrictEqual(getAuthTokenRequests(), [{
+      clientId: 'komunitin-social',
+      grantType: 'urn:ietf:params:oauth:grant-type:token-exchange',
+      scope: Scope.Superadmin,
+      subjectToken: superadmin.token,
+    }])
+    assert.deepStrictEqual(
+      getAccountingRequestPaths(),
+      [
+        `GET /${currency.code}/accounts`,
+        `POST /${currency.code}/accounts`,
+      ],
+    )
   })
 
   test('PATCH /:code/members/:member adopts existing accounting account by member code', async () => {

--- a/social/test/mocks/handlers.ts
+++ b/social/test/mocks/handlers.ts
@@ -52,6 +52,8 @@ let accountingCurrencyDeleteStatus = 204
 let accountingCurrencyDeleteDetail = 'Mock accounting currency delete failure'
 let accountingAccountDeleteStatus = 204
 let accountingAccountDeleteDetail = 'Mock accounting delete failure'
+let accountingAccountCreateStatus = 201
+let accountingAccountCreateDetail = 'Mock accounting account creation failure'
 let notificationsEventStatus = 201
 let notificationsEvents: unknown[] = []
 
@@ -132,6 +134,11 @@ export const setAccountingAccountDeleteStatus = (status: number, detail = 'Mock 
   accountingAccountDeleteDetail = detail
 }
 
+export const setAccountingAccountCreateStatus = (status: number, detail = 'Mock accounting account creation failure') => {
+  accountingAccountCreateStatus = status
+  accountingAccountCreateDetail = detail
+}
+
 export const setAccountingCurrencyDeleteStatus = (status: number, detail = 'Mock accounting currency delete failure') => {
   accountingCurrencyDeleteStatus = status
   accountingCurrencyDeleteDetail = detail
@@ -205,6 +212,8 @@ export const resetMockState = () => {
   accountingCurrencyDeleteDetail = 'Mock accounting currency delete failure'
   accountingAccountDeleteStatus = 204
   accountingAccountDeleteDetail = 'Mock accounting delete failure'
+  accountingAccountCreateStatus = 201
+  accountingAccountCreateDetail = 'Mock accounting account creation failure'
   notificationsEventStatus = 201
   notificationsEvents = []
   notificationsRequests = []
@@ -248,7 +257,11 @@ export const handlers = [
       || params.get('client_secret') !== process.env.SOCIAL_CLIENT_SECRET
       || params.get('subject_token_type') !== 'urn:ietf:params:oauth:token-type:access_token'
       || !tokenRequest.subjectToken
-      || (tokenRequest.scope !== Scope.AccountingRead && tokenRequest.scope !== Scope.AccountingWrite)
+      || (
+        tokenRequest.scope !== Scope.AccountingRead
+        && tokenRequest.scope !== Scope.AccountingWrite
+        && tokenRequest.scope !== Scope.Superadmin
+      )
     ) {
       return HttpResponse.json({ error: 'invalid_request' }, { status: 400 })
     }
@@ -381,6 +394,10 @@ export const handlers = [
     const unauthorized = requireAccountingAuthorization(request)
     if (unauthorized) {
       return unauthorized
+    }
+
+    if (accountingAccountCreateStatus !== 201) {
+      return jsonApiError(accountingAccountCreateStatus, accountingAccountCreateDetail)
     }
 
     const currencyCode = String(params.currencyCode)

--- a/social/test/unit/auth.test.ts
+++ b/social/test/unit/auth.test.ts
@@ -40,10 +40,12 @@ test('isolates cached tokens by subject token and scope', async (t) => {
 
   const subjectRead = await exchangeAccountingToken('isolated-subject-a', Scope.AccountingRead)
   const subjectWrite = await exchangeAccountingToken('isolated-subject-a', Scope.AccountingWrite)
+  const subjectSuperadmin = await exchangeAccountingToken('isolated-subject-a', Scope.Superadmin)
   const otherSubjectRead = await exchangeAccountingToken('isolated-subject-b', Scope.AccountingRead)
 
   assert.strictEqual(subjectRead, 'isolated-subject-a-accounting:read')
   assert.strictEqual(subjectWrite, 'isolated-subject-a-accounting:write')
+  assert.strictEqual(subjectSuperadmin, 'isolated-subject-a-superadmin')
   assert.strictEqual(otherSubjectRead, 'isolated-subject-b-accounting:read')
   assert.strictEqual(
     await exchangeAccountingToken('isolated-subject-a', Scope.AccountingRead),
@@ -54,10 +56,14 @@ test('isolates cached tokens by subject token and scope', async (t) => {
     subjectWrite,
   )
   assert.strictEqual(
+    await exchangeAccountingToken('isolated-subject-a', Scope.Superadmin),
+    subjectSuperadmin,
+  )
+  assert.strictEqual(
     await exchangeAccountingToken('isolated-subject-b', Scope.AccountingRead),
     otherSubjectRead,
   )
-  assert.strictEqual(requests, 3)
+  assert.strictEqual(requests, 4)
 })
 
 test('shares an in-flight exchange for concurrent calls', async (t) => {


### PR DESCRIPTION
DEF-007 — Superadmin member acceptance fails in Accounting
Severity: P1
Environment: this run, reset local development stack
Reproduction: 1/1 acceptance attempt; pending state remained rolled back
Prerequisites: pending administrator member QJRX0000; logged in as superadmin
Steps: open account management and accept the pending member
Expected: Social activates the member and Accounting creates its account
Actual: Social PATCH returns 500; Accounting POST /QJRX/accounts returns 403 because the superadmin user is not present in currency QJRX
Sanitized log: User <superadmin-user-id> not found in currency QJRX
Evidence: screenshots/SMK-006-superadmin-after-administrator-acceptance.png
Boundary: Social member-status synchronization → Accounting authorization